### PR TITLE
Allow loader (e.g. Homebrew Channel) to pass 2 arguments instead of 3

### DIFF
--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -464,7 +464,7 @@ int main(int argc, char *argv[])
 	InitGUIThreads();
 
 	bool autoboot = false;
-	if(argc > 3 && argv[1] != NULL && argv[2] != NULL && argv[3] != NULL)
+	if(argc > 2 && argv[1] != NULL && argv[2] != NULL)
 	{
 		autoboot = true;
 		ResetBrowser();
@@ -487,7 +487,7 @@ int main(int argc, char *argv[])
 		strncpy(arg_filename, argv[2], sizeof(arg_filename));
 		strncpy(GCSettings.LoadFolder, dir.c_str(), sizeof(GCSettings.LoadFolder));
 		OpenGameList();
-		strncpy(GCSettings.Exit_Dol_File, argv[3], sizeof(GCSettings.Exit_Dol_File));
+		strncpy(GCSettings.Exit_Dol_File, argv[3] != NULL ? argv[3] : "", sizeof(GCSettings.Exit_Dol_File));
 		if(argc > 5 && argv[4] != NULL && argv[5] != NULL)
 		{
 			sscanf(argv[4], "%08x", &GCSettings.Exit_Channel[0]);

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -487,7 +487,7 @@ int main(int argc, char *argv[])
 		strncpy(arg_filename, argv[2], sizeof(arg_filename));
 		strncpy(GCSettings.LoadFolder, dir.c_str(), sizeof(GCSettings.LoadFolder));
 		OpenGameList();
-		strncpy(GCSettings.Exit_Dol_File, argv[3] != NULL ? argv[3] : "", sizeof(GCSettings.Exit_Dol_File));
+		strncpy(GCSettings.Exit_Dol_File, argc > 3 && argv[3] != NULL ? argv[3] : "", sizeof(GCSettings.Exit_Dol_File));
 		if(argc > 5 && argv[4] != NULL && argv[5] != NULL)
 		{
 			sscanf(argv[4], "%08x", &GCSettings.Exit_Channel[0]);


### PR DESCRIPTION
With this patch, I can load a particular ROM directly from a Homebrew Channel entry by specifying the directory and filename as arguments in meta.xml. This way I can use the HBC as an ersatz game loader, with a different copy of snes9xgx (and a different controller configuration) per game.

If you want to merge this, you should check to make sure it doesn't break Wiiflow, etc.

The same patch might also work with fceugx and vbagx (not tested.)