### PR TITLE
MSU1 fixes backported

### DIFF
--- a/source/snes9x/apu/apu.cpp
+++ b/source/snes9x/apu/apu.cpp
@@ -510,7 +510,7 @@ bool8 S9xInitSound (int buffer_ms, int lag_ms)
 		return (FALSE);
 	if (msu::landing_buffer)
 		delete[] msu::landing_buffer;
-	msu::landing_buffer = new uint8[msu::buffer_size * 2];
+	msu::landing_buffer = (uint8*) new uint32[msu::buffer_size / 2]; // Ensure 4-byte alignment
 	if (!msu::landing_buffer)
 		return (FALSE);
 
@@ -635,6 +635,8 @@ void S9xDeinitAPU (void)
 		delete[] msu::resample_buffer;
 		msu::resample_buffer = NULL;
 	}
+	
+	S9xMSU1DeInit();
 }
 
 static inline int S9xAPUGetClock (int32 cpucycles)

--- a/source/snes9x/apu/resampler.h
+++ b/source/snes9x/apu/resampler.h
@@ -17,7 +17,7 @@ class Resampler : public ring_buffer
         {
         }
 
-        ~Resampler ()
+        virtual ~Resampler ()
         {
         }
 

--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -4082,7 +4082,10 @@ static bool8 ReadBPSPatch (Reader *r, long, int32 &rom_size)
 
 		switch((int)mode) {
 			case SourceRead:
-				while(length--) patched_rom[outputOffset++] = Memory.ROM[outputOffset];
+				while(length--) {
+					patched_rom[outputOffset] = Memory.ROM[outputOffset];
+					outputOffset++;
+				}
 				break;
 			case TargetRead:
 				while(length--) patched_rom[outputOffset++] = data[addr++];
@@ -4337,7 +4340,7 @@ void CMemory::CheckForAnyPatch (const char *rom_filename, bool8 header, int32 &r
 		}
 	}
 
-	// Mercurial Magic (MSU-1 distribution pack)
+    // Mercurial Magic (MSU-1 distribution pack)
 	if (strcasecmp(ext, "msu1") && strcasecmp(ext, ".msu1"))
 	{
 		_makepath(fname, drive, dir, name, "msu1");
@@ -4350,8 +4353,9 @@ void CMemory::CheckForAnyPatch (const char *rom_filename, bool8 header, int32 &r
 			{
 				printf(" in %s", fname);
 
-				ret = ReadBPSPatch(new unzReader(file), offset, rom_size);
-				unzCloseCurrentFile(file);
+				Stream *s = new unzStream(msu1file);
+				ret = ReadBPSPatch(s, offset, rom_size);
+				s->closeStream();
 
 				if (ret)
 					printf("!\n");

--- a/source/snes9x/msu1.h
+++ b/source/snes9x/msu1.h
@@ -196,6 +196,8 @@
 #include <stdint.h>
 #include <sys\stat.h>
 
+#define MSU1_REVISION 0x02
+
 struct SMSU1
 {
 	uint8	MSU1_STATUS;
@@ -211,8 +213,7 @@ struct SMSU1
 };
 
 enum SMSU1_FLAG {
-	Revision		= 0x02,	//max: 0x07
-	AudioResume		= 0x04,
+	Revision		= 0x07,	// bitmask, not the actual version number
 	AudioError		= 0x08,
 	AudioPlaying	= 0x10,
 	AudioRepeating	= 0x20,
@@ -230,8 +231,9 @@ extern struct SMSU1	MSU1;
 
 void S9xResetMSU(void);
 void S9xMSU1Init(void);
+void S9xMSU1DeInit(void);
 bool S9xMSU1ROMExists(void);
-STREAM S9xMSU1OpenFile(char *msu_ext);
+STREAM S9xMSU1OpenFile(const char *msu_ext, bool skip_unpacked = FALSE);
 void S9xMSU1Init(void);
 void S9xMSU1Generate(size_t sample_count);
 uint8 S9xMSU1ReadPort(uint8 port);


### PR DESCRIPTION
The following fixes are backported from the Snes9x master branch:
- Release msu data and audio streams on exit, use unzClose when closing
- Fix MSU-1 channel swap on loop
- Ensure all MSU-1 reads are stereo channel aligned
- Clean up S9xMSU1Generate code
- Fix MSU1 swapping.
- Fix casting on MSU1 volume
- Get rid of "Unable to find msu file" console spam