### PR TITLE
Update build to version 4.3.8

### DIFF
--- a/hbc/meta.xml
+++ b/hbc/meta.xml
@@ -2,8 +2,8 @@
 <app version="1">
   <name>Snes9x GX</name>
   <coder>Tantric, Zopenko, Askot</coder>
-  <version>4.3.5-fix1</version>
-  <release_date>20160216</release_date>
+  <version>4.3.8</version>
+  <release_date>20180805</release_date>
   <short_description>Super Nintendo Emulator</short_description> 
   <long_description>A port of Snes9x to the Wii.</long_description> 
   <ahb_access />

--- a/readme.txt
+++ b/readme.txt
@@ -32,14 +32,18 @@ Wii homebrew is WiiBrew (www.wiibrew.org).
 |                                                          UPDATE HISTORY  |
 •˜———–—––-- - —————————––––– ———–—––-- - —————————––––– ———–—––-- - ————————•
 
-[4.3.8]
+[4.3.8 - August 5, 2018]
 
 * Add MSU1 support (thanks qwertymodo!)
 * Add BPS soft-patching support (thanks qwertymodo!)
 * Allow loader to pass two arguments instead of three (libertyernie)
-* backport some MSU1 fixes from snes9x
+* Backport some MSU1 fixes from snes9x
 * Fix a few potential crashes caused by the GUI
 * Compiled with latest libOGC/devkitPPC
+* Remove update check completely. 
+* Compatibility fixes for newer devkitppc.
+* Compile fixes for Gamecube
+* Compile fixes for Linux 
 
 [4.3.7 - December 9, 2016]
 

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -20,7 +20,7 @@
 #include "filelist.h"
 
 #define APPNAME 			"Snes9x GX"
-#define APPVERSION 			"4.3.7"
+#define APPVERSION 			"4.3.8"
 #define APPFOLDER 			"snes9xgx"
 #define PREF_FILE_NAME		"settings.xml"
 


### PR DESCRIPTION
* Add MSU1 support (thanks qwertymodo!)
* Add BPS soft-patching support (thanks qwertymodo!)
* Allow loader to pass two arguments instead of three (libertyernie)
* Backport some MSU1 fixes from snes9x
* Fix a few potential crashes caused by the GUI
* Compiled with latest libOGC/devkitPPC
* Remove update check completely. 
* Compatibility fixes for newer devkitppc.
* Compile fixes for Gamecube
* Compile fixes for Linux