### PR TITLE
Code cleanup and fix include references

### DIFF
--- a/source/cheatmgr.cpp
+++ b/source/cheatmgr.cpp
@@ -9,8 +9,8 @@
  ***************************************************************************/
 
 
-#include "port.h"
-#include "cheats.h"
+#include "snes9x/port.h"
+#include "snes9x/cheats.h"
 
 #include "snes9xgx.h"
 #include "fileop.h"

--- a/source/filter.cpp
+++ b/source/filter.cpp
@@ -22,7 +22,7 @@
 #include "filter.h"
 #include "video.h"
 #include "snes9xgx.h"
-#include "memmap.h"
+#include "snes9x/memmap.h"
 
 #include "menu.h"
 

--- a/source/filter.h
+++ b/source/filter.h
@@ -18,7 +18,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include "snes9x.h"
+#include "snes9x/snes9x.h"
  
 enum RenderFilter{
 	FILTER_NONE = 0,

--- a/source/gui/gui_filebrowser.cpp
+++ b/source/gui/gui_filebrowser.cpp
@@ -9,7 +9,7 @@
  ***************************************************************************/
 
 #include "gui.h"
-#include "filebrowser.h"
+#include "../filebrowser.h"
 
 /**
  * Constructor for the GuiFileBrowser class.

--- a/source/gui/gui_savebrowser.cpp
+++ b/source/gui/gui_savebrowser.cpp
@@ -9,7 +9,7 @@
  ***************************************************************************/
 
 #include "gui.h"
-#include "filebrowser.h"
+#include "../filebrowser.h"
 
 /**
  * Constructor for the GuiSaveBrowser class.

--- a/source/snes9x/apu/SNES_SPC.h
+++ b/source/snes9x/apu/SNES_SPC.h
@@ -10,9 +10,9 @@
 #include "blargg_endian.h"
 
 #ifdef DEBUGGER
-#include "snes9x.h"
-#include "display.h"
-#include "debug.h"
+#include "../snes9x.h"
+#include "../display.h"
+#include "../debug.h"
 #endif
 
 struct SNES_SPC {

--- a/source/snes9x/apu/apu.cpp
+++ b/source/snes9x/apu/apu.cpp
@@ -180,11 +180,11 @@
 
 
 #include <math.h>
-#include "snes9x.h"
+#include "../snes9x.h"
 #include "apu.h"
-#include "msu1.h"
-#include "snapshot.h"
-#include "display.h"
+#include "../msu1.h"
+#include "../snapshot.h"
+#include "../display.h"
 #include "linear_resampler.h"
 #include "hermite_resampler.h"
 

--- a/source/snes9x/apu/apu.h
+++ b/source/snes9x/apu/apu.h
@@ -179,7 +179,7 @@
 #ifndef _APU_H_
 #define _APU_H_
 
-#include "snes9x.h"
+#include "../snes9x.h"
 #include "SNES_SPC.h"
 
 typedef void (*apu_callback) (void *);

--- a/source/snes9x/apu/linear_resampler.h
+++ b/source/snes9x/apu/linear_resampler.h
@@ -4,7 +4,7 @@
 #define __LINEAR_RESAMPLER_H
 
 #include "resampler.h"
-#include "snes9x.h"
+#include "../snes9x.h"
 
 static const int    f_prec = 15;
 static const uint32 f__one = (1 << f_prec);

--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -183,14 +183,6 @@
 #include <numeric>
 #include <assert.h>
 
-#ifdef UNZIP_SUPPORT
-#include "unzip/unzip.h"
-#endif
-
-#ifdef JMA_SUPPORT
-#include "jma/s9x-jma.h"
-#endif
-
 #include "snes9x.h"
 #include "memmap.h"
 #include "apu/apu.h"

--- a/source/snes9x/reader.cpp
+++ b/source/snes9x/reader.cpp
@@ -178,9 +178,6 @@
 // Abstract the details of reading from zip files versus FILE *'s.
 
 #include <string>
-#ifdef UNZIP_SUPPORT
-#include "unzip.h"
-#endif
 #include "snes9x.h"
 #include "reader.h"
 

--- a/source/utils/gettext.cpp
+++ b/source/utils/gettext.cpp
@@ -5,8 +5,8 @@
 #include <unistd.h>
 
 #include "gettext.h"
-#include "filelist.h"
-#include "snes9xgx.h"
+#include "../filelist.h"
+#include "../snes9xgx.h"
 
 typedef struct _MSG
 {


### PR DESCRIPTION
- Fixed all broken include references
- Cleanup memmap.cpp code by removing UNZIP and JMA SUPPORT code which are not used
- Cleanup reader.cpp code by removing the UNZIP SUPPORT reference to unzip.h