### PR TITLE
 Fixed: Code cleanup and fix include references

### DIFF
--- a/source/snes9x/apu/SNES_SPC.h
+++ b/source/snes9x/apu/SNES_SPC.h
@@ -10,9 +10,9 @@
 #include "blargg_endian.h"
 
 #ifdef DEBUGGER
-#include "snes9x.h"
-#include "display.h"
-#include "debug.h"
+#include "../snes9x.h"
+#include "../display.h"
+#include "../debug.h"
 #endif
 
 struct SNES_SPC {

--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -183,14 +183,6 @@
 #include <numeric>
 #include <assert.h>
 
-#ifdef UNZIP_SUPPORT
-#include "unzip/unzip.h"
-#endif
-
-#ifdef JMA_SUPPORT
-#include "jma/s9x-jma.h"
-#endif
-
 #include "snes9x.h"
 #include "memmap.h"
 #include "apu/apu.h"

--- a/source/snes9x/reader.cpp
+++ b/source/snes9x/reader.cpp
@@ -178,9 +178,6 @@
 // Abstract the details of reading from zip files versus FILE *'s.
 
 #include <string>
-#ifdef UNZIP_SUPPORT
-#include "unzip.h"
-#endif
 #include "snes9x.h"
 #include "reader.h"
 


### PR DESCRIPTION
After reverting the commit from core 1.56 a few of these changes were not applied.

- Fixed all broken include references
- Cleanup memmap.cpp code by removing UNZIP and JMA SUPPORT code which are not used
- Cleanup reader.cpp code by removing the UNZIP SUPPORT reference to unzip.h