### PR TITLE
Add VM folder as source and update Readme

### DIFF
--- a/Makefile.gc
+++ b/Makefile.gc
@@ -19,8 +19,8 @@ TARGET		:=	snes9xgx-gc
 TARGETDIR   :=  executables
 BUILD		:=	build_gc
 SOURCES		:=	source source/images source/sounds source/fonts source/lang \
-				source/gui source/utils source/utils/sz \
-				source/snes9x source/snes9x/apu source/utils/vm
+				source/gui source/utils source/utils/sz source/utils/vm \
+				source/snes9x source/snes9x/apu
 INCLUDES	:=	source source/snes9x
 
 #---------------------------------------------------------------------------------

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -19,7 +19,7 @@ TARGET		:=	snes9xgx-wii
 TARGETDIR   :=  executables
 BUILD		:=	build_wii
 SOURCES		:=	source source/images source/sounds source/fonts source/lang \
-				source/gui source/utils source/utils/sz \
+				source/gui source/utils source/utils/sz source/utils/vm \
 				source/snes9x source/snes9x/apu
 INCLUDES	:=	source source/snes9x
 

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,8 @@ Wii homebrew is WiiBrew (www.wiibrew.org).
 * Improved WiiFlow integration
 * Fixed mangled image when switching between HQ2x and scanlines filters
 * Added Wii U GamePad support (thanks Fix94!)
+* Fixed black screen Tengai Makyou Zero
+* Fixed black screen Chou Aniki
 
 [4.3.9 - August 24, 2018]
 


### PR DESCRIPTION
Occasionally the build won't compile because the source/vm folder was missing and I updated the Readme.