### PR TITLE
Decrease the number of opcodes executed on the SA1 to 3

### DIFF
--- a/source/snes9x/sa1cpu.cpp
+++ b/source/snes9x/sa1cpu.cpp
@@ -312,7 +312,7 @@ void S9xSA1MainLoop (void)
 		}
 	}
 
-	for (int i = 0; i < 5 && !(Memory.FillRAM[0x2200] & 0x60); i++)
+	for (int i = 0; i < 3 && !(Memory.FillRAM[0x2200] & 0x60); i++)
 	{
 	#ifdef DEBUGGER
 		if (SA1.Flags & TRACE_FLAG)


### PR DESCRIPTION
This fixes slowdowns in SA1 games.