### PR TITLE
don't apply SA1 hack for Kirby Super Star

### DIFF
--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -3868,18 +3868,19 @@ void CMemory::ApplyROMFixes (void)
 			match_nn("SANKYO Fever! \xCC\xA8\xB0\xCA\xDE\xB0!"))   // SANKYO Fever! Fever!
 			Timings.APUSpeedup = 1; */
 	#ifdef GEKKO
-		if (match_na ("EARTHWORM JIM 2")						|| // Earthworm Jim 2
-			match_na ("NBA Hangtime")							|| // NBA Hang Time
-			match_na ("MSPACMAN")								|| // Ms Pacman
-			match_na ("THE MASK")								|| // The Mask
-			match_na ("PRIMAL RAGE")							|| // Primal Rage
-			match_na ("PORKY PIGS HAUNTED")						|| // Porky Pig's Haunted Holiday
-			match_na ("Big Sky Trooper")						|| // Big Sky Trooper
-			match_id ("A35")									|| // Mechwarrior 3050 / Battle Tech 3050
-			match_na ("DOOM TROOPERS"))							   // Doom Troopers
+		if (match_na ("EARTHWORM JIM 2")			    || // Earthworm Jim 2
+			match_na ("NBA Hangtime")			    || // NBA Hang Time
+			match_na ("MSPACMAN")				    || // Ms Pacman
+			match_na ("THE MASK")				    || // The Mask
+			match_na ("PRIMAL RAGE")			    || // Primal Rage
+			match_na ("PORKY PIGS HAUNTED")			    || // Porky Pig's Haunted Holiday
+			match_na ("Big Sky Trooper")			    || // Big Sky Trooper
+			match_id ("A35")				    || // Mechwarrior 3050 / Battle Tech 3050
+			match_na ("DOOM TROOPERS"))			       // Doom Troopers
 			Timings.APUAllowTimeOverflow = TRUE;
 
-		if (match_id("AFJJ") || match_id("AFJE")) { // Kirby's Dream Land 3
+		if (match_id("AFJJ") || match_id("AFJE")		    || // Hoshi no Kirby 3, Kirby's Dream Land 3
+			match_id("AKFE"))				     { // Kirby Super Star
 			Timings.SA1Cycles = 5;
 		}
 		else {


### PR DESCRIPTION
Tested both Kirby's Dream Land 3 and Kirby Super Star both are working correct.

I also tested jikkyou oshaberi parodius (another SA1 game) these new settings don't affect the game.

And I took out some breaks.