### PR TITLE
Removed SuperFX Overclock and add Overclock hack for Yoshi's Island

### DIFF
--- a/hbc/meta.xml
+++ b/hbc/meta.xml
@@ -3,7 +3,7 @@
   <name>Snes9x GX</name>
   <coder>Tantric, Zopenko, Askot</coder>
   <version>4.4.0</version>
-  <release_date>20181113</release_date>
+  <release_date>20181116</release_date>
   <short_description>Super Nintendo Emulator</short_description> 
   <long_description>A port of Snes9x to the Wii.</long_description> 
   <ahb_access />

--- a/readme.txt
+++ b/readme.txt
@@ -43,9 +43,12 @@ Wii homebrew is WiiBrew (www.wiibrew.org).
 * Added BS-X BIOS loading
 * Fixed Tengai Mekyou Zero black screen
 * Fixed Chou Aniki black screen
-* Get SuperFX Overclock working with core 1.57
+* Removed SuperFX Overclock
+* Set 40 MHz Overclock as default for Yoshi's story
 * Get APU Hacks working with core 1.57 to fix Earthworm Jim 2
 * Adjusted SA1 settings to fix Super Mario RPG slowdowns with core 1.57
+* Fixed Kirby's Dreamland 3 intro
+* Fixed Kirby Super Star intro
 
 [4.3.9 - August 24, 2018]
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3157,7 +3157,6 @@ static int MenuSettingsVideo()
 	sprintf(options.name[i++], "Crosshair");
 	sprintf(options.name[i++], "Video Mode");
 	sprintf(options.name[i++], "Show Framerate");
-	sprintf(options.name[i++], "SuperFX Overclock");
 	options.length = i;
 	
 #ifdef HW_DOL
@@ -3249,20 +3248,6 @@ static int MenuSettingsVideo()
 				Settings.AutoDisplayMessages ^= 1;
 				Settings.DisplayFrameRate ^= 1;
 				break;
-			case 8:
-				GCSettings.sfxOverclock++;
-				if (GCSettings.sfxOverclock > 2) {
-					GCSettings.sfxOverclock = 0;
-				}
-				switch(GCSettings.sfxOverclock)
-				{
-					case 0: Settings.SuperFXSpeedPerLine = 5823405; break;
-					case 1: Settings.SuperFXSpeedPerLine = 0.417 * 40.5e6; break;
-					case 2: Settings.SuperFXSpeedPerLine = 0.417 * 60.5e6; break;
-				}
-				S9xResetSuperFX();
-				S9xReset();
-				break;
 		}
 
 		if(ret >= 0 || firstRun)
@@ -3309,15 +3294,6 @@ static int MenuSettingsVideo()
 					sprintf (options.value[6], "PAL (60Hz)"); break;
 			}
 			sprintf (options.value[7], "%s", Settings.DisplayFrameRate ? "On" : "Off");
-			switch(GCSettings.sfxOverclock)
-			{
-				case 0:
-					sprintf (options.value[8], "Default"); break;
-				case 1:
-					sprintf (options.value[8], "40 Mhz"); break;
-				case 2:
-					sprintf (options.value[8], "60 Mhz"); break;
-			}
 			optionBrowser.TriggerUpdate();
 		}
 

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -150,7 +150,6 @@ preparePrefsData ()
 	createXMLSetting("FilterMethod", "Filter Method", toStr(GCSettings.FilterMethod));
 	createXMLSetting("xshift", "Horizontal Video Shift", toStr(GCSettings.xshift));
 	createXMLSetting("yshift", "Vertical Video Shift", toStr(GCSettings.yshift));
-	createXMLSetting("sfxOverclock", "SuperFX Overclock", toStr(GCSettings.sfxOverclock));
 
 	createXMLSection("Menu", "Menu Settings");
 
@@ -335,10 +334,6 @@ decodePrefsData ()
 			loadXMLSetting(&GCSettings.xshift, "xshift");
 			loadXMLSetting(&GCSettings.yshift, "yshift");
 
-			//Emulation Settings
-
-			loadXMLSetting(&GCSettings.sfxOverclock, "sfxOverclock");
-
 			// Menu Settings
 
 			loadXMLSetting(&GCSettings.WiimoteOrientation, "WiimoteOrientation");
@@ -503,9 +498,8 @@ DefaultSettings ()
 	Settings.FrameTimePAL = 20000;
 	Settings.FrameTimeNTSC = 16667;
 
-	GCSettings.sfxOverclock = 0;
 	/* Initialize SuperFX CPU to normal speed by default */
-	Settings.SuperFXSpeedPerLine = 5823405;
+	Timings.SuperFXSpeedPerLine = 5823405;
 	
 	Settings.SuperFXClockMultiplier = 100;
 	

--- a/source/snes9x/fxemu.cpp
+++ b/source/snes9x/fxemu.cpp
@@ -216,7 +216,7 @@ void S9xResetSuperFX (void)
 	// FIXME: Snes9x only runs the SuperFX at the end of every line.
 	// 5823405 is a magic number that seems to work for most games.
 	#ifdef GEKKO
-	SuperFX.speedPerLine = (uint32) (Settings.SuperFXSpeedPerLine * ((1.0f / Memory.ROMFramesPerSecond) / ((float) (Timings.V_Max)))); 
+	SuperFX.speedPerLine = (uint32) (Timings.SuperFXSpeedPerLine * ((1.0f / Memory.ROMFramesPerSecond) / ((float) (Timings.V_Max)))); 
 	#else
 	SuperFX.speedPerLine = (uint32) (5823405 * ((1.0 / (float) Memory.ROMFramesPerSecond) / ((float) (Timings.V_Max)))); 
 	#endif

--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -3886,6 +3886,13 @@ void CMemory::ApplyROMFixes (void)
 		else {
 			Timings.SA1Cycles = 3;
 		}
+		
+		if (match_id("YI"))							     { // Super Mario World 2 Yoshi's Island
+			Timings.SuperFXSpeedPerLine = 0.417 * 40.5e6;
+		}
+		else {
+			Timings.SuperFXSpeedPerLine = 5823405;
+		}
 	#endif
 	}
 

--- a/source/snes9x/snes9x.h
+++ b/source/snes9x/snes9x.h
@@ -368,9 +368,10 @@ struct STimings
 	int32	NMIDMADelay;	// The delay of NMI trigger after DMA transfers. Snes9x cannot emulate correctly.
 	int32	IRQFlagChanging;	// This value is just a hack.
 	int32	APUSpeedup;
-	bool8	APUAllowTimeOverflow;
 #ifdef GEKKO
+	bool8	APUAllowTimeOverflow;
 	int32	SA1Cycles;
+	float	SuperFXSpeedPerLine;
 #endif
 };
 
@@ -488,7 +489,6 @@ struct SSettings
 	bool8	UpAndDown;
 
 	bool8	OpenGLEnable;
-	float	SuperFXSpeedPerLine;
 
 	uint32	SuperFXClockMultiplier;
 	int	OneClockCycle;

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -478,14 +478,6 @@ int main(int argc, char *argv[])
 		autoboot = GCSettings.AutoloadGame;
 	}
 
-	switch (GCSettings.sfxOverclock)
-	{
-		case 0: Settings.SuperFXSpeedPerLine = 5823405; break;
-		case 1: Settings.SuperFXSpeedPerLine = 0.417 * 40.5e6; break;
-		case 2: Settings.SuperFXSpeedPerLine = 0.417 * 60.5e6; break;
-		S9xResetSuperFX();
-	}
-
 	while (1) // main loop
 	{
 		if(!autoboot) {

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -117,8 +117,6 @@ struct SGCSettings{
 	int		Rumble;
 	int		language;
 	int		PreviewImage;
-
-	int		sfxOverclock;
 };
 
 void ExitApp();


### PR DESCRIPTION
* Removed SuperFX Overclock
* Set 40 MHz Overclock as default for Yoshi's story

Tested it with several SuperFX and other games, don't see any issues:
- Yoshi's Island (SuperFX)
- Jikkyou Oshaberi Parodius (SuperFX)
- Earthworm Jim 2
- Super Mario World (with MSU1)
- Mega Man X (with MSU1)
- Kirby Super Star