### PR TITLE
Backport NTSC frame time adjustment

### DIFF
--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -501,7 +501,7 @@ DefaultSettings ()
 
 	// Frame timings in 50hz and 60hz cpu mode
 	Settings.FrameTimePAL = 20000;
-	Settings.FrameTimeNTSC = 16667;
+	Settings.FrameTimeNTSC = 16666;
 
 	GCSettings.sfxOverclock = 0;
 	/* Initialize SuperFX CPU to normal speed by default */

--- a/source/xenon/s9xconfig.cpp
+++ b/source/xenon/s9xconfig.cpp
@@ -127,7 +127,7 @@ DefaultSettings ()
 
 	// Frame timings in 50hz and 60hz cpu mode
 	Settings.FrameTimePAL = 20000;
-	Settings.FrameTimeNTSC = 16667;
+	Settings.FrameTimeNTSC = 16666;
 
 	Settings.ForceNTSC = 0;
 	Settings.ForcePAL = 0;


### PR DESCRIPTION
16666 NTSC frame time is closer to correct than 16667.