### PR TITLE
Change widescreen setting

### DIFF
--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -443,7 +443,7 @@ DefaultSettings ()
 	GCSettings.render = 3; // Filtered (sharp)
 	GCSettings.FilterMethod = FILTER_NONE;	// no hq2x
 
-	GCSettings.widescreen = 1; // aspect ratio correction
+	GCSettings.widescreen = 0; // no aspect ratio correction
 	GCSettings.zoomHor = 1.0; // horizontal zoom level
 	GCSettings.zoomVert = 1.0; // vertical zoom level
 	GCSettings.xshift = 0; // horizontal video shift


### PR DESCRIPTION
Change widescreen setting to no autocorrection, this fixes mangled screen on newer tv's. 
I experienced it myself by renaming the config file while testing. 

It adds more logic to not use a correction by default only when it's necessary. 
There is an open issue where a user pointed that this settings is only changes on Snes9x GX and not in the other GX emulators:
https://github.com/dborth/snes9xgx/issues/793