### PR TITLE
Swapping preview images with + button

### DIFF
--- a/source/gui/gui_trigger.cpp
+++ b/source/gui/gui_trigger.cpp
@@ -133,6 +133,10 @@ s8 GuiTrigger::WPAD_Stick(u8 stick, int axis)
 			center = js->center.x;
 		}
 
+		if(min == max) {
+			return 0;
+		}
+
 		if (pos > max) return 127;
 		if (pos < min) return -128;
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -948,7 +948,7 @@ static int MenuGameSelection()
 	GuiFileBrowser gameBrowser(330, 268);
 	gameBrowser.SetPosition(20, 98);
 	ResetBrowser();
-		
+	
 	GuiImage bgPreview(&bgPreviewImg);
 	bgPreview.SetPosition(365, 98);
 	
@@ -1042,7 +1042,7 @@ static int MenuGameSelection()
 		if(previousBrowserIndex != browser.selIndex)
 		{			
 			previousBrowserIndex = browser.selIndex;
-			snprintf(imagePath, MAXJOLIET, "%s%s/%s.png", pathPrefix[GCSettings.LoadMethod], GCSettings.ImageFolder, browserList[browser.selIndex].displayname);
+			snprintf(imagePath, MAXJOLIET, "%s%s/%s.png", pathPrefix[GCSettings.LoadMethod], ImageFolder(), browserList[browser.selIndex].displayname);
 			
 			AllocSaveBuffer();
 			int width, height;
@@ -3999,16 +3999,13 @@ static int MenuSettingsMenu()
 			switch(GCSettings.PreviewImage)
 			{
 				case 0:	
-					sprintf(options.value[6], "Screenshots"); 
-					snprintf(GCSettings.ImageFolder, MAXJOLIET, "%s", GCSettings.ScreenshotsFolder);
+					sprintf(options.value[6], "Screenshots");
 					break; 
 				case 1:	
-					sprintf(options.value[6], "Covers");	  
-					snprintf(GCSettings.ImageFolder, MAXJOLIET, "%s", GCSettings.CoverFolder);
+					sprintf(options.value[6], "Covers");
 					break; 
 				case 2:	
 					sprintf(options.value[6], "Artwork");
-					snprintf(GCSettings.ImageFolder, MAXJOLIET, "%s", GCSettings.ArtworkFolder);
 					break; 
 			}
 			

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -949,8 +949,15 @@ static int MenuGameSelection()
 	gameBrowser.SetPosition(20, 98);
 	ResetBrowser();
 	
+	GuiTrigger trigPlusMinus;
+	trigPlusMinus.SetButtonOnlyTrigger(-1, WPAD_BUTTON_PLUS | WPAD_CLASSIC_BUTTON_PLUS, PAD_TRIGGER_Z, WIIDRC_BUTTON_PLUS);
+	
 	GuiImage bgPreview(&bgPreviewImg);
-	bgPreview.SetPosition(365, 98);
+	GuiButton bgPreviewBtn(bgPreview.GetWidth(), bgPreview.GetHeight());
+	bgPreviewBtn.SetImage(&bgPreview);
+	bgPreviewBtn.SetPosition(365, 98);
+	bgPreviewBtn.SetTrigger(&trigPlusMinus);
+	int previousPreviewImg = GCSettings.PreviewImage;
 	
 	GuiImage preview;
 	preview.SetAlignment(ALIGN_CENTRE, ALIGN_MIDDLE);
@@ -965,7 +972,7 @@ static int MenuGameSelection()
 	mainWindow->Append(&titleTxt);
 	mainWindow->Append(&gameBrowser);
 	mainWindow->Append(&buttonWindow);
-	mainWindow->Append(&bgPreview);
+	mainWindow->Append(&bgPreviewBtn);
 	mainWindow->Append(&preview);
 	ResumeGui();
 
@@ -1039,9 +1046,10 @@ static int MenuGameSelection()
 		}
 		
 		//update gamelist image
-		if(previousBrowserIndex != browser.selIndex)
+		if(previousBrowserIndex != browser.selIndex || previousPreviewImg != GCSettings.PreviewImage)
 		{			
 			previousBrowserIndex = browser.selIndex;
+			previousPreviewImg = GCSettings.PreviewImage;
 			snprintf(imagePath, MAXJOLIET, "%s%s/%s.png", pathPrefix[GCSettings.LoadMethod], ImageFolder(), browserList[browser.selIndex].displayname);
 			
 			AllocSaveBuffer();
@@ -1069,6 +1077,11 @@ static int MenuGameSelection()
 			menu = MENU_SETTINGS;
 		else if(exitBtn.GetState() == STATE_CLICKED)
 			ExitRequested = 1;
+		else if(bgPreviewBtn.GetState() == STATE_CLICKED)
+		{
+			GCSettings.PreviewImage = (GCSettings.PreviewImage + 1) % 3;
+			bgPreviewBtn.ResetState();
+		}
 	}
 
 	HaltParseThread(); // halt parsing
@@ -1077,7 +1090,7 @@ static int MenuGameSelection()
 	mainWindow->Remove(&titleTxt);
 	mainWindow->Remove(&buttonWindow);
 	mainWindow->Remove(&gameBrowser);
-	mainWindow->Remove(&bgPreview);
+	mainWindow->Remove(&bgPreviewBtn);
 	mainWindow->Remove(&preview);
 	MEM_DEALLOC(imgBuffer);
 	return menu;

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -132,7 +132,6 @@ preparePrefsData ()
 	createXMLSetting("ScreenshotsFolder", "Screenshots Folder", GCSettings.ScreenshotsFolder);
 	createXMLSetting("CoverFolder", "Covers Folder", GCSettings.CoverFolder);
 	createXMLSetting("ArtworkFolder", "Artwork Folder", GCSettings.ArtworkFolder);
-	createXMLSetting("ImageFolder", "Image Folder", GCSettings.ImageFolder);
 	
 	createXMLSection("Network", "Network Settings");
 
@@ -317,7 +316,6 @@ decodePrefsData ()
 			loadXMLSetting(GCSettings.ScreenshotsFolder, "ScreenshotsFolder", sizeof(GCSettings.ScreenshotsFolder));
 			loadXMLSetting(GCSettings.CoverFolder, "CoverFolder", sizeof(GCSettings.CoverFolder));
 			loadXMLSetting(GCSettings.ArtworkFolder, "ArtworkFolder", sizeof(GCSettings.ArtworkFolder));
-			loadXMLSetting(GCSettings.ImageFolder, "ImageFolder", sizeof(GCSettings.ImageFolder));
 			
 			// Network Settings
 
@@ -433,7 +431,6 @@ DefaultSettings ()
 	sprintf (GCSettings.ScreenshotsFolder, "%s/screenshots", APPFOLDER); // Path to screenshot files
 	sprintf (GCSettings.CoverFolder, "%s/covers", APPFOLDER); // Path to cover files
 	sprintf (GCSettings.ArtworkFolder, "%s/artwork", APPFOLDER); // Path to artwork files
-	sprintf (GCSettings.ImageFolder, "%s/screenshots", APPFOLDER);
 	GCSettings.AutoLoad = 1;
 	GCSettings.AutoSave = 1;
 

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -558,3 +558,13 @@ int main(int argc, char *argv[])
 		} // emulation loop
 	} // main loop
 }
+
+char* ImageFolder()
+{
+	switch(GCSettings.PreviewImage)
+	{
+		case 1 : return GCSettings.CoverFolder; break;
+		case 2 : return GCSettings.ArtworkFolder; break;
+		default: return GCSettings.ScreenshotsFolder; break;
+	}
+}

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -92,7 +92,6 @@ struct SGCSettings{
 	char	ScreenshotsFolder[MAXPATHLEN]; // Path to screenshots files
 	char	CoverFolder[MAXPATHLEN]; 	// Path to cover files
 	char	ArtworkFolder[MAXPATHLEN]; 	// Path to artwork files
-	char 	ImageFolder[MAXPATHLEN]; 	// Saved image folder path
 	int		AutoloadGame;
 
 	char	smbip[80];
@@ -122,6 +121,8 @@ struct SGCSettings{
 	
 	int		Interpolation;
 };
+
+char* ImageFolder();
 
 void ExitApp();
 void ShutdownWii();


### PR DESCRIPTION
Getting into the menu settings and changing the preview image is a bit annoying when we can just swap images pressing one button
Also I have removed the ImageFolder char* since it can always be retrieved from GCSettings.PreviewImage