### PR TITLE
Port option to not append "Auto" to save filenames from vbagx and fceugx

### DIFF
--- a/source/filebrowser.cpp
+++ b/source/filebrowser.cpp
@@ -290,7 +290,10 @@ bool MakeFilePath(char filepath[], int type, char * filename, int filenum)
 					if(filenum == -1)
 						sprintf(file, "%s.%s", filename, ext);
 					else if(filenum == 0)
-						sprintf(file, "%s Auto.%s", filename, ext);
+						if (GCSettings.AppendAuto <= 0)
+							sprintf(file, "%s.%s", filename, ext);
+						else
+							sprintf(file, "%s Auto.%s", filename, ext);
 					else
 						sprintf(file, "%s %i.%s", filename, filenum, ext);
 				}

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3707,6 +3707,7 @@ static int MenuSettingsFile()
 	sprintf(options.name[i++], "Artwork Folder");
 	sprintf(options.name[i++], "Auto Load");
 	sprintf(options.name[i++], "Auto Save");
+	sprintf(options.name[i++], "Append Auto to .SAV Files");
 	options.length = i;
 
 	for(i=0; i < options.length; i++)
@@ -3800,6 +3801,12 @@ static int MenuSettingsFile()
 				if (GCSettings.AutoSave > 3)
 					GCSettings.AutoSave = 0;
 				break;
+
+			case 10:
+				GCSettings.AppendAuto++;
+				if (GCSettings.AppendAuto > 1)
+					GCSettings.AppendAuto = 0;
+				break;
 		}
 
 		if(ret >= 0 || firstRun)
@@ -3873,6 +3880,9 @@ static int MenuSettingsFile()
 			else if (GCSettings.AutoSave == 1) sprintf (options.value[9],"SRAM");
 			else if (GCSettings.AutoSave == 2) sprintf (options.value[9],"Snapshot");
 			else if (GCSettings.AutoSave == 3) sprintf (options.value[9],"Both");
+
+			if (GCSettings.AppendAuto == 0) sprintf (options.value[10], "Off");
+			else if (GCSettings.AppendAuto == 1) sprintf (options.value[10], "On");
 
 			optionBrowser.TriggerUpdate();
 		}

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -128,6 +128,7 @@ preparePrefsData ()
 	createXMLSetting("LoadFolder", "Load Folder", GCSettings.LoadFolder);
 	createXMLSetting("LastFileLoaded", "Last File Loaded", GCSettings.LastFileLoaded);
 	createXMLSetting("SaveFolder", "Save Folder", GCSettings.SaveFolder);
+	createXMLSetting("AppendAuto", "Append Auto to .SAV Files", toStr(GCSettings.AppendAuto));
 	createXMLSetting("CheatFolder", "Cheats Folder", GCSettings.CheatFolder);
 	createXMLSetting("ScreenshotsFolder", "Screenshots Folder", GCSettings.ScreenshotsFolder);
 	createXMLSetting("CoverFolder", "Covers Folder", GCSettings.CoverFolder);
@@ -312,6 +313,7 @@ decodePrefsData ()
 			loadXMLSetting(GCSettings.LoadFolder, "LoadFolder", sizeof(GCSettings.LoadFolder));
 			loadXMLSetting(GCSettings.LastFileLoaded, "LastFileLoaded", sizeof(GCSettings.LastFileLoaded));
 			loadXMLSetting(GCSettings.SaveFolder, "SaveFolder", sizeof(GCSettings.SaveFolder));
+			loadXMLSetting(&GCSettings.AppendAuto, "AppendAuto");
 			loadXMLSetting(GCSettings.CheatFolder, "CheatFolder", sizeof(GCSettings.CheatFolder));
 			loadXMLSetting(GCSettings.ScreenshotsFolder, "ScreenshotsFolder", sizeof(GCSettings.ScreenshotsFolder));
 			loadXMLSetting(GCSettings.CoverFolder, "CoverFolder", sizeof(GCSettings.CoverFolder));

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -85,6 +85,7 @@ struct SGCSettings{
 	int		AutoSave;
 	int		LoadMethod; // For ROMS: Auto, SD, DVD, USB, Network (SMB)
 	int		SaveMethod; // For SRAM, Freeze, Prefs: Auto, SD, USB, SMB
+	int		AppendAuto; // 0 - no, 1 - yes
 	char	LoadFolder[MAXPATHLEN]; 	// Path to game files
 	char	LastFileLoaded[MAXPATHLEN]; // Last file loaded filename
 	char	SaveFolder[MAXPATHLEN]; 	// Path to save files

--- a/source/sram.cpp
+++ b/source/sram.cpp
@@ -85,6 +85,9 @@ LoadSRAMAuto (bool silent)
 	if (LoadSRAM(filepath, silent))
 		return true;
 
+	if (!GCSettings.AppendAuto)
+		return false;
+
 	// look for file with no number or Auto appended
 	if(!MakeFilePath(filepath, FILE_SRAM, Memory.ROMFilename, -1))
 		return false;


### PR DESCRIPTION
This is a useful option when doing a lot of save file transfers. "Auto" in the title causes the save to not be recognized by some other emulators. Having it be optional just saves a step every time. Originally implemented in vbagx and later ported to fceugx.