### PR TITLE
Backport c4emu and gfx fixes

### DIFF
--- a/source/snes9x/c4emu.cpp
+++ b/source/snes9x/c4emu.cpp
@@ -1022,11 +1022,11 @@ void S9xSetC4 (uint8 byte, uint16 Address)
 					if (Memory.C4RAM[0x1f4d] != 0x0e)
 						printf("$7f4d=%02x, expected 0e for command 54 %02x\n", Memory.C4RAM[0x1f4d], Memory.C4RAM[0x1f4d]);
 				#endif
-					int64   b = (int64) READ_3WORD(Memory.C4RAM + 0x1f80);
-					int64   c = b << 40;
-					int64	a = SAR(c, 30);
-					a = SAR(c, 10);
+					int64 a = (int64)READ_3WORD(Memory.C4RAM + 0x1f80);
+					a |= 0xffffffffff000000 * ((a >> 23) & 1);
+					//printf("%08X%08X\n", (uint32) (a>>32), (uint32) (a&0xFFFFFFFF));
 					a *= a;
+					//printf("%08X%08X\n", (uint32) (a>>32), (uint32) (a&0xFFFFFFFF));
 					WRITE_3WORD(Memory.C4RAM + 0x1f83, a);
 					WRITE_3WORD(Memory.C4RAM + 0x1f86, (a >> 24));
 					break;

--- a/source/snes9x/gfx.cpp
+++ b/source/snes9x/gfx.cpp
@@ -200,6 +200,8 @@ void S9xBuildDirectColourMaps (void)
 void S9xStartScreenRefresh (void)
 {
 	GFX.InterlaceFrame = !GFX.InterlaceFrame;
+	if (GFX.DoInterlace)
+		GFX.DoInterlace--;
 
 	if (IPPU.RenderThisFrame)
 	{
@@ -210,9 +212,6 @@ void S9xStartScreenRefresh (void)
 				IPPU.RenderThisFrame = FALSE;
 				return;
 			}
-
-			if (GFX.DoInterlace)
-				GFX.DoInterlace--;
 
 			S9xGraphicsScreenResize();
 


### PR DESCRIPTION
C4emu backport:
C4: Do the sign extend manually.
Revert "MSVC 2005 bugfix"

GFX backport:
Fix GCC warning about indentation. 
GFX.DoInterlace-- should occur even if we don't render frame.