### PR TITLE
- fixed crash when used as wiiflow plugin.

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -138,7 +138,11 @@ static void ResetText()
 	LoadLanguage();
 
 	if(mainWindow)
+	{
+		HaltGui();
 		mainWindow->ResetText();
+		ResumeGui();
+	}
 }
 
 static int currentLanguage = -1;
@@ -187,10 +191,8 @@ void ChangeLanguage() {
 		}
 	}
 #endif
-	HaltGui();
 	ResetText();
 	currentLanguage = GCSettings.language;
-	ResumeGui();
 }
 
 /****************************************************************************


### PR DESCRIPTION
when args are checked the mainwindow gui has not been created so the resumegui causes a crash. i moved it slightly to under the check if mainwindow to fix the issue. this will also fix fceugx and vbagx.