### PR TITLE
Snes9x - Restore MSU1_AUDIO_POS.

### DIFF
--- a/source/snes9x/msu1.cpp
+++ b/source/snes9x/msu1.cpp
@@ -416,6 +416,8 @@ void S9xMSU1PostLoadState(void)
 
 	if (MSU1.MSU1_STATUS & AudioPlaying)
 	{
+		uint32 savedPosition = MSU1.MSU1_AUDIO_POS;
+
 		if (AudioOpen())
 		{
             REVERT_STREAM(audioStream, 4, 0);
@@ -424,6 +426,7 @@ void S9xMSU1PostLoadState(void)
 			audioLoopPos <<= 2;
 			audioLoopPos += 8;
 
+			MSU1.MSU1_AUDIO_POS = savedPosition;
             REVERT_STREAM(audioStream, MSU1.MSU1_AUDIO_POS, 0);
 		}
 		else


### PR DESCRIPTION
Snes9x:
- Restore MSU1_AUDIO_POS.
- Restore MSU1 playback position correctly.