### PR TITLE
Change L+R+X+Y trigger to go back to L+R+SELECT

### DIFF
--- a/source/input.cpp
+++ b/source/input.cpp
@@ -605,8 +605,7 @@ bool MenuRequested()
 			(userInput[i].pad.substickX < -70) ||
 			(userInput[i].pad.btns_h & PAD_TRIGGER_L &&
 			userInput[i].pad.btns_h & PAD_TRIGGER_R &&
-			userInput[i].pad.btns_h & PAD_BUTTON_X &&
-			userInput[i].pad.btns_h & PAD_BUTTON_Y)
+			userInput[i].pad.btns_h & PAD_BUTTON_SELECT)
 			#ifdef HW_RVL
 			|| (userInput[i].wpad->btns_h & WPAD_BUTTON_HOME) ||
 			(userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_HOME) ||


### PR DESCRIPTION
I want to propose to use L+R+SELECT instead of L+R+X+Y because L+R+X+Y can be easily pressed at the same time while playing fighting games for example. 