### PR TITLE
Enabling DisplayFrameRate and DisplayClock at the same time

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3339,11 +3339,21 @@ static int MenuSettingsVideo()
 					GCSettings.videomode = 0;
 				break;
 			case 7:
-				Settings.AutoDisplayMessages ^= 1;
+				if (Settings.AutoDisplayMessages == 1) {
+					// do nothing
+				}
+				else {
+					Settings.AutoDisplayMessages ^= 1;
+				}
 				Settings.DisplayFrameRate ^= 1;
 				break;
 			case 8:
-				Settings.AutoDisplayMessages ^= 1;
+				if (Settings.AutoDisplayMessages == 1) {
+					// do nothing
+				}
+				else {
+					Settings.AutoDisplayMessages ^= 1;
+				}
 				Settings.DisplayTime ^= 1;
 				break;
 			case 9:


### PR DESCRIPTION
This makes it possible to enable DisplayFrameRate and DisplayClock at the same time.