### PR TITLE
Fix Dragon Ball Z Hyper Dimension black screen

### DIFF
--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -3160,13 +3160,31 @@ void CMemory::Map_SA1LoROMMap (void)
 
 	map_hirom_offset(0xc0, 0xff, 0x0000, 0xffff, CalculatedSize, 0);
 
-	map_space(0x00, 0x3f, 0x3000, 0x37ff, FillRAM);
-	map_space(0x80, 0xbf, 0x3000, 0x37ff, FillRAM);
+	#ifdef GEKKO
+	if (match_id("AZIJ"))                    { // Dragon Ball Z - Hyper Dimension (J)	
+		map_space(0x00, 0x3f, 0x3000, 0x3fff, FillRAM);
+		map_space(0x80, 0xbf, 0x3000, 0x3fff, FillRAM);
+	}
+	else {
+		map_space(0x00, 0x3f, 0x3000, 0x37ff, FillRAM);
+		map_space(0x80, 0xbf, 0x3000, 0x37ff, FillRAM);
+	}
+	#endif
+
+
 	map_index(0x00, 0x3f, 0x6000, 0x7fff, MAP_BWRAM, MAP_TYPE_I_O);
 	map_index(0x80, 0xbf, 0x6000, 0x7fff, MAP_BWRAM, MAP_TYPE_I_O);
 
-	for (int c = 0x40; c < 0x4f; c++)
-		map_space(c, c, 0x0000, 0xffff, SRAM + (c & 3) * 0x10000);
+	#ifdef GEKKO
+	if (match_id("AZIJ"))                    { // Dragon Ball Z - Hyper Dimension (J)	
+		for (int c = 0x40; c < 0x80; c++)
+			map_space(c, c, 0x0000, 0xffff, SRAM + (c & 1) * 0x10000);
+	}
+	else {
+		for (int c = 0x40; c < 0x4f; c++)
+			map_space(c, c, 0x0000, 0xffff, SRAM + (c & 3) * 0x10000);
+	}
+	#endif
 
 	map_WRAM();
 


### PR DESCRIPTION
- Commit "Backport Reduced version of Vitor's fix for SA1 speed throttle" caused a black screen when starting DBZ Hyper Dimension, this change fixes that.