### PR TITLE
Added support for serial port 2 (SP2 / SD2SP2) on Gamecube

### DIFF
--- a/source/filebrowser.cpp
+++ b/source/filebrowser.cpp
@@ -71,6 +71,8 @@ int autoLoadMethod()
 		device = DEVICE_SD_SLOTA;
 	else if(ChangeInterface(DEVICE_SD_SLOTB, SILENT))
 		device = DEVICE_SD_SLOTB;
+	else if(ChangeInterface(DEVICE_SD_PORT2, SILENT))
+		device = DEVICE_SD_PORT2;
 	else if(ChangeInterface(DEVICE_DVD, SILENT))
 		device = DEVICE_DVD;
 	else if(ChangeInterface(DEVICE_SMB, SILENT))
@@ -104,6 +106,8 @@ int autoSaveMethod(bool silent)
 		device = DEVICE_SD_SLOTA;
 	else if(ChangeInterface(DEVICE_SD_SLOTB, SILENT))
 		device = DEVICE_SD_SLOTB;
+	else if(ChangeInterface(DEVICE_SD_PORT2, SILENT))
+		device = DEVICE_SD_PORT2;
 	else if(ChangeInterface(DEVICE_SMB, SILENT))
 		device = DEVICE_SMB;
 	else if(!silent)
@@ -173,7 +177,8 @@ bool IsDeviceRoot(char * path)
 		strcmp(path, "dvd:/")   == 0 ||
 		strcmp(path, "smb:/")   == 0 ||
 		strcmp(path, "carda:/") == 0 ||
-		strcmp(path, "cardb:/") == 0)
+		strcmp(path, "cardb:/") == 0 ||
+		strcmp(path, "port2:/") == 0)
 	{
 		return true;
 	}
@@ -614,6 +619,14 @@ int BrowserChangeFolder()
 		AddBrowserEntry();
 		sprintf(browserList[i].filename, "cardb:/");
 		sprintf(browserList[i].displayname, "SD Gecko Slot B");
+		browserList[i].length = 0;
+		browserList[i].isdir = 1;
+		browserList[i].icon = ICON_SD;
+		i++;
+
+		AddBrowserEntry();
+		sprintf(browserList[i].filename, "port2:/");
+		sprintf(browserList[i].displayname, "SD in SP2");
 		browserList[i].length = 0;
 		browserList[i].isdir = 1;
 		browserList[i].icon = ICON_SD;

--- a/source/fileop.cpp
+++ b/source/fileop.cpp
@@ -53,6 +53,7 @@ bool isMounted[7] = { false, false, false, false, false, false, false };
 #else
 	const DISC_INTERFACE* carda = &__io_gcsda;
 	const DISC_INTERFACE* cardb = &__io_gcsdb;
+	const DISC_INTERFACE* port2 = &__io_gcsd2;
 	const DISC_INTERFACE* dvd = &__io_gcdvd;
 #endif
 
@@ -205,6 +206,7 @@ void UnmountAllFAT()
 #else
 	fatUnmount("carda:");
 	fatUnmount("cardb:");
+	fatUnmount("port2:");
 #endif
 }
 
@@ -242,11 +244,15 @@ static bool MountFAT(int device, int silent)
 			sprintf(name2, "carda:");
 			disc = carda;
 			break;
-
 		case DEVICE_SD_SLOTB:
 			sprintf(name, "cardb");
 			sprintf(name2, "cardb:");
 			disc = cardb;
+			break;
+		case DEVICE_SD_PORT2:
+			sprintf(name, "port2");
+			sprintf(name2, "port2:");
+			disc = port2;
 			break;
 #endif
 		default:
@@ -291,6 +297,7 @@ void MountAllFAT()
 #else
 	MountFAT(DEVICE_SD_SLOTA, SILENT);
 	MountFAT(DEVICE_SD_SLOTB, SILENT);
+	MountFAT(DEVICE_SD_PORT2, SILENT);
 #endif
 }
 
@@ -369,6 +376,11 @@ bool FindDevice(char * filepath, int * device)
 		*device = DEVICE_SD_SLOTB;
 		return true;
 	}
+	else if(strncmp(filepath, "port2:", 6) == 0)
+	{
+		*device = DEVICE_SD_PORT2;
+		return true;
+	}
 	else if(strncmp(filepath, "dvd:", 4) == 0)
 	{
 		*device = DEVICE_DVD;
@@ -409,6 +421,7 @@ bool ChangeInterface(int device, bool silent)
 #else
 		case DEVICE_SD_SLOTA:
 		case DEVICE_SD_SLOTB:
+		case DEVICE_SD_PORT2:
 #endif
 			mounted = MountFAT(device, silent);
 			break;

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3844,6 +3844,10 @@ static int MenuSettingsFile()
 				GCSettings.LoadMethod++;
 			if(GCSettings.SaveMethod == DEVICE_SD_SLOTB)
 				GCSettings.SaveMethod++;
+			if(GCSettings.LoadMethod == DEVICE_SD_PORT2)
+				GCSettings.LoadMethod++;
+			if(GCSettings.SaveMethod == DEVICE_SD_PORT2)
+				GCSettings.SaveMethod++;
 			#endif
 
 			// correct load/save methods out of bounds
@@ -3859,6 +3863,7 @@ static int MenuSettingsFile()
 			else if (GCSettings.LoadMethod == DEVICE_SMB) sprintf (options.value[0],"Network");
 			else if (GCSettings.LoadMethod == DEVICE_SD_SLOTA) sprintf (options.value[0],"SD Gecko Slot A");
 			else if (GCSettings.LoadMethod == DEVICE_SD_SLOTB) sprintf (options.value[0],"SD Gecko Slot B");
+			else if (GCSettings.LoadMethod == DEVICE_SD_PORT2) sprintf (options.value[0],"SD in SP2");
 
 			if (GCSettings.SaveMethod == DEVICE_AUTO) sprintf (options.value[1],"Auto Detect");
 			else if (GCSettings.SaveMethod == DEVICE_SD) sprintf (options.value[1],"SD");
@@ -3866,6 +3871,7 @@ static int MenuSettingsFile()
 			else if (GCSettings.SaveMethod == DEVICE_SMB) sprintf (options.value[1],"Network");
 			else if (GCSettings.SaveMethod == DEVICE_SD_SLOTA) sprintf (options.value[1],"SD Gecko Slot A");
 			else if (GCSettings.SaveMethod == DEVICE_SD_SLOTB) sprintf (options.value[1],"SD Gecko Slot B");
+			else if (GCSettings.SaveMethod == DEVICE_SD_PORT2) sprintf (options.value[1],"SD in SP2");
 
 			snprintf (options.value[2], 35, "%s", GCSettings.LoadFolder);
 			snprintf (options.value[3], 35, "%s", GCSettings.SaveFolder);

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -666,9 +666,10 @@ bool LoadPrefs()
 	sprintf(filepath[3], "sd:/%s", APPFOLDER);
 	sprintf(filepath[4], "usb:/%s", APPFOLDER);
 #else
-	numDevices = 2;
+	numDevices = 3;
 	sprintf(filepath[0], "carda:/%s", APPFOLDER);
 	sprintf(filepath[1], "cardb:/%s", APPFOLDER);
+	sprintf(filepath[2], "port2:/%s", APPFOLDER);
 #endif
 
 	for(int i=0; i<numDevices; i++)

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -29,7 +29,7 @@
 #define SILENT 1
 
 const char pathPrefix[9][8] =
-{ "", "sd:/", "usb:/", "dvd:/", "smb:/", "carda:/", "cardb:/" };
+{ "", "sd:/", "usb:/", "dvd:/", "smb:/", "carda:/", "cardb:/", "port2:/" };
 
 enum {
 	DEVICE_AUTO,
@@ -38,7 +38,8 @@ enum {
 	DEVICE_DVD,
 	DEVICE_SMB,
 	DEVICE_SD_SLOTA,
-	DEVICE_SD_SLOTB
+	DEVICE_SD_SLOTB,
+	DEVICE_SD_PORT2
 };
 
 enum {


### PR DESCRIPTION
Changes are functional on my Gamecube using SD2SP2.  Tested booting snes9xgx from SP2, loading ROMs from SP2, and saving/load from SP2.

Build was tested using devkitPPC r35 and libogc 1.8.23.

Open to input regarding naming that was used ("port2") vs something like "slot2" or "sp2".