### PR TITLE
Snes9x - Fix some warnings. / Remove out-of-bounds access with macs rifle data.

### DIFF
--- a/source/snes9x/controls.cpp
+++ b/source/snes9x/controls.cpp
@@ -3515,11 +3515,17 @@ void S9xControlPreSaveState (struct SControlSnapshot *s)
 		for (int k = 0; k < 2; k++)
 			COPY(mp5[j].pads[k]);
 
+	assert(i == sizeof(s->internal));
+
+	#undef COPY
+	#define COPY(x)	{ memcpy((char *) s->internal_macs + i, &(x), sizeof(x)); i += sizeof(x); }
+	i = 0;
+
 	COPY(macsrifle.x);
 	COPY(macsrifle.y);
 	COPY(macsrifle.buttons);
 
-	assert(i == sizeof(s->internal) + sizeof(s->internal_macs));
+	assert(i == sizeof(s->internal_macs));
 
 #undef COPY
 
@@ -3594,11 +3600,15 @@ void S9xControlPostLoadState (struct SControlSnapshot *s)
 
 		if (s->ver > 3)
 		{
+			#undef COPY
+			#define COPY(x)	{ memcpy(&(x), (char *) s->internal_macs + i, sizeof(x)); i += sizeof(x); }
+			i = 0;
+
 			COPY(macsrifle.x);
 			COPY(macsrifle.y);
 			COPY(macsrifle.buttons);
 
-			assert(i == sizeof(s->internal) + sizeof(s->internal_macs));
+			assert(i == sizeof(s->internal_macs));
 		}
 
 	#undef COPY

--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -2562,7 +2562,7 @@ void CMemory::InitROM (void)
 	if (Settings.ForcePAL)
 		Settings.PAL = TRUE;
 	else
-	if (!Settings.BS && ((ROMRegion >= 2) && (ROMRegion <= 12) || ROMRegion == 18)) // 18 is used by "Tintin in Tibet (Europe) (En,Es,Sv)"
+	if (!Settings.BS && (((ROMRegion >= 2) && (ROMRegion <= 12)) || ROMRegion == 18)) // 18 is used by "Tintin in Tibet (Europe) (En,Es,Sv)"
 		Settings.PAL = TRUE;
 	else
 		Settings.PAL = FALSE;

--- a/source/snes9x/movie.cpp
+++ b/source/snes9x/movie.cpp
@@ -460,7 +460,7 @@ static int read_movie_extrarominfo (FILE *fd, SMovie *movie)
 
 	ptr += 3; // zero bytes
 	movie->ROMCRC32 = Read32(ptr);
-	sstrncpy(movie->ROMName, (char *) ptr, 23);
+	memcpy(movie->ROMName, (char *) ptr, 23);
 
 	return (SUCCESS);
 }

--- a/source/snes9x/port.h
+++ b/source/snes9x/port.h
@@ -151,12 +151,6 @@ void SetInfoDlgColor(unsigned char, unsigned char, unsigned char);
 #endif  // __LIBRETRO__
 #endif  // __WIN32__
 
-inline void sstrncpy(char *dst, const char *src, size_t size)
-{
-    strncpy(dst, src, size - 1);
-    dst[size - 1] = '\0';
-}
-
 #if defined(__DJGPP) || defined(__WIN32__)
 #define SLASH_STR	"\\"
 #define SLASH_CHAR	'\\'


### PR DESCRIPTION
Snes9x - Fix some warnings.
Snes9x - Remove out-of-bounds access with macs rifle data.