### PR TITLE
Remove BSX Bios dependency

### DIFF
--- a/source/filebrowser.cpp
+++ b/source/filebrowser.cpp
@@ -50,7 +50,7 @@ bool inSz = false;
 unsigned long SNESROMSize = 0;
 bool loadingFile = false;
 
-extern bool isBSX();
+//extern bool isBSX();
 
 /****************************************************************************
 * autoLoadMethod()
@@ -380,7 +380,8 @@ static bool IsValidROM()
 				if (strcasecmp(p, ".smc") == 0 ||
 					strcasecmp(p, ".fig") == 0 ||
 					strcasecmp(p, ".sfc") == 0 ||
-					strcasecmp(p, ".swc") == 0)
+					strcasecmp(p, ".swc") == 0 ||
+					strcasecmp(p, ".bs") == 0) 
 				{
 					if(zippedFilename) free(zippedFilename);
 					return true;
@@ -490,14 +491,14 @@ int WiiFileLoader()
 
 	SNESROMSize = Memory.HeaderRemove(size, Memory.ROM);
 	bsxBiosLoadFailed = false;
-
+	/*
 	if(isBSX()) {
 		sprintf (filepath, "%s%s/BS-X.bin", pathPrefix[GCSettings.LoadMethod], APPFOLDER);
 		if(LoadFile ((char *)Memory.BIOSROM, filepath, 0, 0x100000, SILENT) == 0) {
 			bsxBiosLoadFailed = true;
 		}
 	}
-
+	*/
 	return SNESROMSize;
 }
 
@@ -689,6 +690,7 @@ OpenGameList ()
 	return browser.numEntries;
 }
 
+/* only called when booted with args (mainly from wiiflow) */
 bool AutoloadGame(char* filepath, char* filename) {
 	ResetBrowser();
 

--- a/source/snes9x/bsx.cpp
+++ b/source/snes9x/bsx.cpp
@@ -1256,14 +1256,14 @@ static bool8 is_BSX_BIOS (const uint8 *data, uint32 size)
 	else
 		return (FALSE);
 }
-#ifdef GEKKO
+/*#ifdef GEKKO
 bool isBSX() {
 	if(is_bsx(Memory.ROM + 0x7FC0) == 1 || is_bsx(Memory.ROM + 0xFFC0) == 1) {
 		return true;
 	}
 	return false;
 }
-#endif
+#endif*/
 void S9xInitBSX (void)
 {
 	Settings.BS = FALSE;
@@ -1305,7 +1305,7 @@ void S9xInitBSX (void)
 			uint8	*header = r1 ? Memory.ROM + 0x7FC0 : Memory.ROM + 0xFFC0;
 
 			FlashMode = (header[0x18] & 0xEF) == 0x20 ? FALSE : TRUE;
-			FlashSize = FLASH_SIZE;
+			FlashSize = (header[0x19] & 0x20) ? PSRAM_SIZE : FLASH_SIZE;
 
 			// Fix Block Allocation Flags
 			// (for games that don't have it setup properly,
@@ -1319,7 +1319,7 @@ void S9xInitBSX (void)
 			printf("BS: FlashMode: %d, FlashSize: %x\n", FlashMode, FlashSize);
 #endif
 
-			BSX.bootup = Settings.BSXBootup;
+			BSX.bootup = TRUE;
 
 			if (!BSX_LoadBIOS() && !is_BSX_BIOS(BIOSROM,BIOS_SIZE))
 			{
@@ -1375,11 +1375,33 @@ void S9xResetBSX (void)
 	memset(BSX.output, 0, sizeof(BSX.output));
 
 	// starting from the bios
-	BSX.MMC[0x02] = BSX.MMC[0x03] = BSX.MMC[0x05] = BSX.MMC[0x06] = 0x80;
-	BSX.MMC[0x09] = BSX.MMC[0x0B] = 0x80;
-
-	BSX.MMC[0x07] = BSX.MMC[0x08] = 0x80;
-	BSX.MMC[0x0E] = 0x80;
+	if (BSX.bootup)
+		BSX.MMC[0x07] = BSX.MMC[0x08] = 0x80;
+	else
+	{
+		BSX.MMC[0x02] = FlashMode ? 0x80: 0;
+		
+		// per bios: run from psram or flash card
+		if (FlashSize == PSRAM_SIZE)
+		{
+			memcpy(PSRAM, FlashROM, PSRAM_SIZE);
+		
+			BSX.MMC[0x01] = 0x80;
+			BSX.MMC[0x03] = 0x80;
+			BSX.MMC[0x04] = 0x80;
+			BSX.MMC[0x0C] = 0x80;
+			BSX.MMC[0x0D] = 0x80;
+		}
+		else
+		{
+			BSX.MMC[0x03] = 0x80;
+			BSX.MMC[0x05] = 0x80;
+			BSX.MMC[0x06] = 0x80;
+			BSX.MMC[0x09] = BSX.MMC[0x0B] = 0x80;// not sure if this line is needed
+		}
+		
+		BSX.MMC[0x0E] = 0x80;
+	}
 
 	// default register values
 	BSX.PPU[0x2196 - BSXPPUBASE] = 0x10;


### PR DESCRIPTION
This removes the need of the BSX BIOS.
The changes where send in by fledge68 on GBAtemp:
https://gbatemp.net/threads/snes9x-gx-4-4-0-beta-feedback-requested.521929/page-21

To remove the need of the BSX BIOS is a good idea I only think that we should remove loading the BIOS completely.

Please review this commit.