### PR TITLE
Snes9x - Remove S9xChooseFilename

### DIFF
--- a/source/s9xsupport.cpp
+++ b/source/s9xsupport.cpp
@@ -199,12 +199,6 @@ bool S9xPollPointer(uint32 id, int16 * x, int16 * y)
  * compile. Where possible, they will return an error signal.
  ***************************************************************************/
 
-const char *S9xChooseFilename(bool8 read_only)
-{
-	ExitApp();
-	return NULL;
-}
-
 const char * S9xChooseMovieFilename(bool8 read_only)
 {
 	ExitApp();

--- a/source/snes9x/controls.cpp
+++ b/source/snes9x/controls.cpp
@@ -2269,11 +2269,9 @@ void S9xApplyCommand (s9xcommand_t cmd, int16 data1, int16 data2)
 						break;
 
 					case LoadFreezeFile:
-						S9xUnfreezeGame(S9xChooseFilename(TRUE));
 						break;
 
 					case SaveFreezeFile:
-						S9xFreezeGame(S9xChooseFilename(FALSE));
 						break;
 
 					case LoadOopsFile:

--- a/source/snes9x/display.h
+++ b/source/snes9x/display.h
@@ -48,7 +48,6 @@ const char * S9xStringInput (const char *);
 const char * S9xGetDirectory (enum s9x_getdirtype);
 const char * S9xGetFilename (const char *, enum s9x_getdirtype);
 const char * S9xGetFilenameInc (const char *, enum s9x_getdirtype);
-const char * S9xChooseFilename (bool8);
 const char * S9xBasename (const char *);
 
 // Routines the port has to implement if it uses command-line

--- a/source/xenon/s9xsupport.cpp
+++ b/source/xenon/s9xsupport.cpp
@@ -53,12 +53,6 @@ void S9xExit()
 
 /*** File based functions ***/
 const char *
-S9xChooseFilename(bool8 read_only)
-{
-	return NULL;
-}
-
-const char *
 S9xChooseMovieFilename(bool8 read_only)
 {
 	return NULL;


### PR DESCRIPTION
This is integration of the frontend with the core. Disable
the snapshot button mappings that use it. Any frontend should
implement those port commands its own.