### PR TITLE
Snes9x - Remove S9xChooseMovieFilename

### DIFF
--- a/source/s9xsupport.cpp
+++ b/source/s9xsupport.cpp
@@ -205,12 +205,6 @@ const char *S9xChooseFilename(bool8 read_only)
 	return NULL;
 }
 
-const char * S9xChooseMovieFilename(bool8 read_only)
-{
-	ExitApp();
-	return NULL;
-}
-
 const char * S9xGetDirectory(enum s9x_getdirtype dirtype)
 {
 	ExitApp();

--- a/source/snes9x/controls.cpp
+++ b/source/snes9x/controls.cpp
@@ -2414,15 +2414,15 @@ void S9xApplyCommand (s9xcommand_t cmd, int16 data1, int16 data2)
 						break;
 
 					case BeginRecordingMovie:
-						if (S9xMovieActive())
-							S9xMovieStop(FALSE);
-						S9xMovieCreate(S9xChooseMovieFilename(FALSE), 0xFF, MOVIE_OPT_FROM_RESET, NULL, 0);
+						// if (S9xMovieActive())
+						// 	S9xMovieStop(FALSE);
+						// S9xMovieCreate(S9xChooseMovieFilename(FALSE), 0xFF, MOVIE_OPT_FROM_RESET, NULL, 0);
 						break;
 
 					case LoadMovie:
-						if (S9xMovieActive())
-							S9xMovieStop(FALSE);
-						S9xMovieOpen(S9xChooseMovieFilename(TRUE), FALSE);
+						// if (S9xMovieActive())
+						// 	S9xMovieStop(FALSE);
+						// S9xMovieOpen(S9xChooseMovieFilename(TRUE), FALSE);
 						break;
 
 					case EndRecordingMovie:

--- a/source/snes9x/movie.h
+++ b/source/snes9x/movie.h
@@ -48,7 +48,6 @@ int S9xMovieGetInfo (const char *, struct MovieInfo *);
 void S9xMovieStop (bool8);
 void S9xMovieToggleRecState (void);
 void S9xMovieToggleFrameDisplay (void);
-const char * S9xChooseMovieFilename (bool8);
 
 // methods used by the emulation
 void S9xMovieInit (void);

--- a/source/xenon/s9xsupport.cpp
+++ b/source/xenon/s9xsupport.cpp
@@ -59,12 +59,6 @@ S9xChooseFilename(bool8 read_only)
 }
 
 const char *
-S9xChooseMovieFilename(bool8 read_only)
-{
-	return NULL;
-}
-
-const char *
 S9xGetDirectory(enum s9x_getdirtype dirtype)
 {
 	return NULL;


### PR DESCRIPTION
This is integration of the frontend with the core. Disable
the button mappings that use it. The frontend should implement on
its own.