### PR TITLE
Refactor make files and change artifact output

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -16,9 +16,26 @@ jobs:
     - name: Build
       run: |
         make -j2
+    
+    - name: Copy files
+      run: | 
+        cp -f hbc/* executables/Snes9xGX/apps/snes9xgx/
+        cp -f hbc/* executables/Snes9xGX-GameCube/
+        cp -f README.md executables/Snes9xGX/apps/snes9xgx/
+        cp -f README.md executables/Snes9xGX-GameCube/
 
-    - name: Upload a Build Artifact
+    - name: Upload Wii Build Artifacts
       uses: actions/upload-artifact@v2
       with: 
-        name: executables
-        path: executables/*
+        name: Snes9xGX-Nightly
+        path: |
+         executables/Snes9xGX/
+         !executables/Snes9xGX/apps/snes9xgx/*.elf
+    
+    - name: Upload GameCube Build Artifacts
+      uses: actions/upload-artifact@v2
+      with: 
+        name: Snes9xGX-Nightly-GameCube
+        path: |
+         executables/Snes9xGX-GameCube/
+         !executables/Snes9xGX-GameCube/*.elf

--- a/Makefile.gc
+++ b/Makefile.gc
@@ -11,12 +11,13 @@ include $(DEVKITPPC)/gamecube_rules
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
+# TARGETDIR is the directory where the output files will be placed
 # BUILD is the directory where object files & intermediate files will be placed
 # SOURCES is a list of directories containing source code
 # INCLUDES is a list of directories containing extra header files
 #---------------------------------------------------------------------------------
-TARGET		:=	snes9xgx-gc
-TARGETDIR	:=	executables
+TARGET		:=	boot
+TARGETDIR	:=	executables/Snes9xGX-GameCube
 BUILD		:=	build_gc
 SOURCES		:=	source source/gui source/utils source/utils/sz source/utils/vm \
 				source/snes9x source/snes9x/apu
@@ -116,7 +117,7 @@ $(BUILD):
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
-	@rm -fr $(BUILD) $(OUTPUT).elf $(OUTPUT).dol
+	@rm -fr $(BUILD) $(TARGETDIR)
 
 #---------------------------------------------------------------------------------
 run:

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -11,12 +11,17 @@ include $(DEVKITPPC)/wii_rules
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
+# TARGETDIR is the directory where the output files will be placed
+# SUBDIR are the directories where the cheats, roms and saves need to be placed
+# ROOTDIR is the root directory of the build
 # BUILD is the directory where object files & intermediate files will be placed
 # SOURCES is a list of directories containing source code
 # INCLUDES is a list of directories containing extra header files
 #---------------------------------------------------------------------------------
-TARGET		:=	snes9xgx-wii
-TARGETDIR	:=	executables
+TARGET		:=	boot
+TARGETDIR	:=	executables/Snes9xGX/apps/snes9xgx
+ROOTDIR		:=	executables/Snes9xGX
+SUBDIR		:=	executables/Snes9xGX/snes9xgx/{cheats,roms,saves}
 BUILD		:=	build_wii
 SOURCES		:=	source source/gui source/utils source/utils/sz \
 				source/snes9x source/snes9x/apu
@@ -110,13 +115,13 @@ export OUTPUT	:=	$(CURDIR)/$(TARGETDIR)/$(TARGET)
 #---------------------------------------------------------------------------------
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
-	@[ -d $(TARGETDIR) ] || mkdir -p $(TARGETDIR)
+	@[ -d $(TARGETDIR) ] || mkdir -p $(TARGETDIR) $(SUBDIR)
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile.wii
 
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
-	@rm -fr $(BUILD) $(OUTPUT).elf $(OUTPUT).dol
+	@rm -fr $(BUILD) $(ROOTDIR)
 
 #---------------------------------------------------------------------------------
 run:


### PR DESCRIPTION
This changes the following:
- Uploads a separate Wii and Gamecube artifact
- Excludes uploading the elf files
- Creates the complete Wii structure under executables/Snes9xGX
- Creates the complete GameCube structure under executables/Snes9xGX-GameCube
- Doesn't upload empty folders like the snes9xgx folder with cheats, roms and saves but it is created in a local environment