### PR TITLE
Create dummy files

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -27,6 +27,9 @@ jobs:
         cp hbc/* dist/Snes9xGX/apps/snes9xgx/
         cp executables/snes9xgx-wii.dol dist/Snes9xGX/apps/snes9xgx/boot.dol
         cp executables/snes9xgx-gc.dol dist/Snes9xGX-GameCube/
+        touch dist/Snes9xGX/snes9xgx/roms/romdir
+        touch dist/Snes9xGX/snes9xgx/cheats/cheatsdir
+        touch dist/Snes9xGX/snes9xgx/saves/savesdir
 
     - name: Upload Wii Build Artifacts
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
Create dummy files otherwise the following folders won't be uploaded in the Wii artifact:
dist/Snes9xGX/snes9xgx
dist/Snes9xGX/snes9xgx/roms
dist/Snes9xGX/snes9xgx/cheats
dist/Snes9xGX/snes9xgx/saves