### PR TITLE
Allow "Original" (240p) render mode in 480p configurations (Taken from niuus' Snes9x RX)

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3502,10 +3502,6 @@ static int MenuSettingsVideo()
 		{
 			firstRun = false;
 
-			// don't allow original render mode if progressive video mode detected
-			if (GCSettings.render==0 && progressive)
-				GCSettings.render++;
-
 			if (GCSettings.render == 0)
 				sprintf (options.value[0], "Original");
 			else if (GCSettings.render == 1)
@@ -3513,9 +3509,9 @@ static int MenuSettingsVideo()
 			else if (GCSettings.render == 2)
 				sprintf (options.value[0], "Unfiltered");
 			else if (GCSettings.render == 3)
-				sprintf (options.value[0], "Filtered (Sharp)");
-			else if (GCSettings.render == 4)
 				sprintf (options.value[0], "Filtered (Soft)");
+			else if (GCSettings.render == 4)
+				sprintf (options.value[0], "Filtered (Sharp)");
 
 			if(GCSettings.widescreen)
 				sprintf (options.value[1], "16:9 Correction");

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3509,9 +3509,9 @@ static int MenuSettingsVideo()
 			else if (GCSettings.render == 2)
 				sprintf (options.value[0], "Unfiltered");
 			else if (GCSettings.render == 3)
-				sprintf (options.value[0], "Filtered (Soft)");
-			else if (GCSettings.render == 4)
 				sprintf (options.value[0], "Filtered (Sharp)");
+			else if (GCSettings.render == 4)
+				sprintf (options.value[0], "Filtered (Soft)");
 
 			if(GCSettings.widescreen)
 				sprintf (options.value[1], "16:9 Correction");


### PR DESCRIPTION
This commit/contribution was taken originally from Snes9x RX, a fork of Snes9x GX by @niuus. More info: https://github.com/niuus/Snes9xRX/commit/4f4627fe

This will allow "Original" render mode to be selectable when using the Wii Options TV Resolution setting for "EDTV or HDTV (480p)" over component cables:
- This caters specifically to LCD / LED users with 240p supported displays, since the option was previously hidden. Users with CRT / PVM / BVM displays with supported 480p Progressive Scan mode will also benefit, since no Wii setting switch will be needed for the "Original" 240p mode to be used.
Hope this will be added to Snes9x GX soon.

@saulfabregwiivc 