### PR TITLE
Added missing Spanish translation for new Reset question prompt

### DIFF
--- a/source/lang/es.lang
+++ b/source/lang/es.lang
@@ -34,6 +34,9 @@ msgstr "Añadir Auto a archivos .SAV"
 msgid "Apr"
 msgstr "Abril"
 
+msgid "Reset this game? Any unsaved progress will be lost."
+msgstr "¿Reiniciar el juego? Se perderá cualquier progreso no guardado."
+
 msgid "Are you sure that you want to reset this game? Any unsaved progress will be lost."
 msgstr "¿Seguro que desea reiniciar el juego? Se perderá cualquier progreso no guardado."
 


### PR DESCRIPTION
Since Snes9xGX and other of your main emulators doesn't have a Spanish translation for the new Reset game question prompt "Reset this game? Any unsaved progress will be lost.", i decided to add one for that.