### PR TITLE
Snes9x - Backport multiple GFX changes

### DIFF
--- a/source/filter.h
+++ b/source/filter.h
@@ -32,14 +32,6 @@ enum RenderFilter{
 	NUM_FILTERS
 };
 
-#define EXT_WIDTH (MAX_SNES_WIDTH + 4)
-#define EXT_PITCH (EXT_WIDTH * 2)
-#define EXT_HEIGHT (MAX_SNES_HEIGHT + 4)
-// Offset into buffer to allow a two pixel border around the whole rendered
-// SNES image. This is a speed up hack to allow some of the image processing
-// routines to access black pixel data outside the normal bounds of the buffer.
-#define EXT_OFFSET (EXT_PITCH * 2 + 2 * 2)
-
 typedef void (*TFilterMethod)(uint8 *srcPtr, uint32 srcPitch, uint8 *dstPtr, uint32 dstPitch, int width, int height);
 
 extern TFilterMethod FilterMethod;

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -507,7 +507,6 @@ DefaultSettings ()
 
 	// Graphics
 	Settings.Transparency = true;
-	Settings.SupportHiRes = true;
 	Settings.MaxSpriteTilesPerLine = 34;
 	Settings.SkipFrames = AUTO_FRAMERATE;
 	Settings.TurboSkipFrames = 19;

--- a/source/snes9x/gfx.cpp
+++ b/source/snes9x/gfx.cpp
@@ -49,15 +49,13 @@ bool8 S9xGraphicsInit (void)
 	S9xInitTileRenderer();
 	memset(BlackColourMap, 0, 256 * sizeof(uint16));
 
-	GFX.RealPPL = GFX.Pitch >> 1;
 	IPPU.OBJChanged = TRUE;
 	Settings.BG_Forced = 0;
 	S9xFixColourBrightness();
 	S9xBuildDirectColourMaps();
 
+	GFX.Screen = &GFX.ScreenBuffer[GFX.RealPPL * 32];
 	GFX.ZERO = (uint16 *) malloc(sizeof(uint16) * 0x10000);
-
-	GFX.ScreenSize = GFX.Pitch / 2 * SNES_HEIGHT_EXTENDED * (Settings.SupportHiRes ? 2 : 1);
 	GFX.SubScreen  = (uint16 *) malloc(GFX.ScreenSize * sizeof(uint16));
 	GFX.ZBuffer    = (uint8 *)  malloc(GFX.ScreenSize);
 	GFX.SubZBuffer = (uint8 *)  malloc(GFX.ScreenSize);
@@ -100,6 +98,9 @@ bool8 S9xGraphicsInit (void)
 		}
 	}
 
+	GFX.EndScreenRefreshCallback = NULL;
+	GFX.EndScreenRefreshCallbackData = NULL;
+
 	return (TRUE);
 }
 
@@ -109,6 +110,9 @@ void S9xGraphicsDeinit (void)
 	if (GFX.SubScreen)  { free(GFX.SubScreen);  GFX.SubScreen  = NULL; }
 	if (GFX.ZBuffer)    { free(GFX.ZBuffer);    GFX.ZBuffer    = NULL; }
 	if (GFX.SubZBuffer) { free(GFX.SubZBuffer); GFX.SubZBuffer = NULL; }
+
+	GFX.EndScreenRefreshCallback = NULL;
+	GFX.EndScreenRefreshCallbackData = NULL;
 }
 
 void S9xGraphicsScreenResize (void)
@@ -119,26 +123,18 @@ void S9xGraphicsScreenResize (void)
 	IPPU.InterlaceOBJ = Memory.FillRAM[0x2133] & 2;
 	IPPU.PseudoHires = Memory.FillRAM[0x2133] & 8;
 		
-	if (Settings.SupportHiRes && (PPU.BGMode == 5 || PPU.BGMode == 6 || IPPU.PseudoHires))
+	if (PPU.BGMode == 5 || PPU.BGMode == 6 || IPPU.PseudoHires)
 	{
-		GFX.RealPPL = GFX.Pitch >> 1;
 		IPPU.DoubleWidthPixels = TRUE;
 		IPPU.RenderedScreenWidth = SNES_WIDTH << 1;
 	}
 	else
 	{
-		#ifdef USE_OPENGL
-		if (Settings.OpenGLEnable)
-			GFX.RealPPL = SNES_WIDTH;
-		else
-		#endif
-			GFX.RealPPL = GFX.Pitch >> 1;
-
 		IPPU.DoubleWidthPixels = FALSE;
 		IPPU.RenderedScreenWidth = SNES_WIDTH;
 	}
 
-	if (Settings.SupportHiRes && IPPU.Interlace)
+	if (IPPU.Interlace)
 	{
 		GFX.PPL = GFX.RealPPL << 1;
 		IPPU.DoubleHeightPixels = TRUE;
@@ -273,6 +269,15 @@ void S9xEndScreenRefresh (void)
 			}
 		}
 	}
+
+	if (GFX.EndScreenRefreshCallback)
+		GFX.EndScreenRefreshCallback(GFX.EndScreenRefreshCallbackData);
+}
+
+void S9xSetEndScreenRefreshCallback(const SGFX::Callback cb, void *const data)
+{
+	GFX.EndScreenRefreshCallback = cb;
+	GFX.EndScreenRefreshCallbackData = data;
 }
 
 void RenderLine (uint8 C)
@@ -467,55 +472,31 @@ void S9xUpdateScreen (void)
 			PPU.RecomputeClipWindows = FALSE;
 		}
 
-		if (Settings.SupportHiRes)
+		if (!IPPU.DoubleWidthPixels && (PPU.BGMode == 5 || PPU.BGMode == 6 || IPPU.PseudoHires))
 		{
-			if (!IPPU.DoubleWidthPixels && (PPU.BGMode == 5 || PPU.BGMode == 6 || IPPU.PseudoHires))
+			// Have to back out of the regular speed hack
+			for (uint32 y = 0; y < GFX.StartY; y++)
 			{
-				#ifdef USE_OPENGL
-				if (Settings.OpenGLEnable && GFX.RealPPL == 256)
-				{
-					// Have to back out of the speed up hack where the low res.
-					// SNES image was rendered into a 256x239 sized buffer,
-					// ignoring the true, larger size of the buffer.
-					GFX.RealPPL = GFX.Pitch >> 1;
+				uint16	*p = GFX.Screen + y * GFX.PPL + 255;
+				uint16	*q = GFX.Screen + y * GFX.PPL + 510;
 
-					for (int32 y = (int32) GFX.StartY - 1; y >= 0; y--)
-					{
-						uint16	*p = GFX.Screen + y * GFX.PPL     + 255;
-						uint16	*q = GFX.Screen + y * GFX.RealPPL + 510;
-
-						for (int x = 255; x >= 0; x--, p--, q -= 2)
-							*q = *(q + 1) = *p;
-					}
-
-					GFX.PPL = GFX.RealPPL; // = GFX.Pitch >> 1 above
-				}
-				else
-				#endif
-				// Have to back out of the regular speed hack
-				for (uint32 y = 0; y < GFX.StartY; y++)
-				{
-					uint16	*p = GFX.Screen + y * GFX.PPL + 255;
-					uint16	*q = GFX.Screen + y * GFX.PPL + 510;
-
-					for (int x = 255; x >= 0; x--, p--, q -= 2)
-						*q = *(q + 1) = *p;
-				}
-
-				IPPU.DoubleWidthPixels = TRUE;
-				IPPU.RenderedScreenWidth = 512;
+				for (int x = 255; x >= 0; x--, p--, q -= 2)
+					*q = *(q + 1) = *p;
 			}
 
-			if (!IPPU.DoubleHeightPixels && IPPU.Interlace && (PPU.BGMode == 5 || PPU.BGMode == 6))
-			{
-				IPPU.DoubleHeightPixels = TRUE;
-				IPPU.RenderedScreenHeight = PPU.ScreenHeight << 1;
-				GFX.PPL = GFX.RealPPL << 1;
-				GFX.DoInterlace = 2;
+			IPPU.DoubleWidthPixels = TRUE;
+			IPPU.RenderedScreenWidth = 512;
+		}
 
-				for (int32 y = (int32) GFX.StartY - 2; y >= 0; y--)
-					memmove(GFX.Screen + (y + 1) * GFX.PPL, GFX.Screen + y * GFX.RealPPL, GFX.PPL * sizeof(uint16));
-			}
+		if (!IPPU.DoubleHeightPixels && IPPU.Interlace && (PPU.BGMode == 5 || PPU.BGMode == 6))
+		{
+			IPPU.DoubleHeightPixels = TRUE;
+			IPPU.RenderedScreenHeight = PPU.ScreenHeight << 1;
+			GFX.PPL = GFX.RealPPL << 1;
+			GFX.DoInterlace = 2;
+
+			for (int32 y = (int32) GFX.StartY - 2; y >= 0; y--)
+				memmove(GFX.Screen + (y + 1) * GFX.PPL, GFX.Screen + y * GFX.RealPPL, GFX.PPL * sizeof(uint16));
 		}
 
 		if ((Memory.FillRAM[0x2130] & 0x30) != 0x30 && (Memory.FillRAM[0x2131] & 0x3f))

--- a/source/snes9x/gfx.h
+++ b/source/snes9x/gfx.h
@@ -11,16 +11,19 @@
 
 struct SGFX
 {
+	typedef void (*Callback)(void *);
+
+	const uint32 Pitch = sizeof(uint16) * MAX_SNES_WIDTH;
+	const uint32 RealPPL = MAX_SNES_WIDTH; // true PPL of Screen buffer
+	const uint32 ScreenSize =  MAX_SNES_WIDTH * MAX_SNES_HEIGHT;	
+	uint16 ScreenBuffer[MAX_SNES_WIDTH * (MAX_SNES_HEIGHT + 64)];	
 	uint16	*Screen;
 	uint16	*SubScreen;
 	uint8	*ZBuffer;
 	uint8	*SubZBuffer;
-	uint32	Pitch;
-	uint32	ScreenSize;
 	uint16	*S;
 	uint8	*DB;
 	uint16	*ZERO;
-	uint32	RealPPL;			// true PPL of Screen buffer
 	uint32	PPL;				// number of pixels on each of Screen buffer
 	uint32	LinesPerTile;		// number of lines in 1 tile (4 or 8 due to interlace)
 	uint16	*ScreenColors;		// screen colors for rendering main
@@ -66,6 +69,9 @@ struct SGFX
 	const char	*InfoString;
 	uint32	InfoStringTimeout;
 	char	FrameDisplayString[256];
+
+	Callback EndScreenRefreshCallback;
+	void *EndScreenRefreshCallbackData;
 };
 
 struct SBG
@@ -201,6 +207,7 @@ struct COLOR_SUB
 
 void S9xStartScreenRefresh (void);
 void S9xEndScreenRefresh (void);
+void S9xSetEndScreenRefreshCallback(SGFX::Callback cb, void *data);
 void S9xBuildDirectColourMaps (void);
 void RenderLine (uint8);
 void S9xComputeClipWindows (void);

--- a/source/snes9x/snapshot.cpp
+++ b/source/snes9x/snapshot.cpp
@@ -1718,11 +1718,11 @@ int S9xUnfreezeFromStream (STREAM stream)
 
 			UnfreezeStructFromCopy(ssi, SnapScreenshot, COUNT(SnapScreenshot), local_screenshot, version);
 
-			IPPU.RenderedScreenWidth  = min(ssi->Width,  IMAGE_WIDTH);
-			IPPU.RenderedScreenHeight = min(ssi->Height, IMAGE_HEIGHT);
+			IPPU.RenderedScreenWidth  = min(ssi->Width,  MAX_SNES_WIDTH);
+			IPPU.RenderedScreenHeight = min(ssi->Height, MAX_SNES_HEIGHT);
 			const bool8 scaleDownX = IPPU.RenderedScreenWidth  < ssi->Width;
 			const bool8 scaleDownY = IPPU.RenderedScreenHeight < ssi->Height && ssi->Height > SNES_HEIGHT_EXTENDED;
-			GFX.DoInterlace = Settings.SupportHiRes ? ssi->Interlaced : 0;
+			GFX.DoInterlace = ssi->Interlaced;
 
 			uint8	*rowpix = ssi->Data;
 			uint16	*screen = GFX.Screen;
@@ -1759,7 +1759,7 @@ int S9xUnfreezeFromStream (STREAM stream)
 			}
 
 			// black out what we might have missed
-			for (uint32 y = IPPU.RenderedScreenHeight; y < (uint32) (IMAGE_HEIGHT); y++)
+			for (uint32 y = IPPU.RenderedScreenHeight; y < (uint32) (MAX_SNES_HEIGHT); y++)
 				memset(GFX.Screen + y * GFX.RealPPL, 0, GFX.RealPPL * 2);
 
 			delete ssi;

--- a/source/snes9x/snes9x.h
+++ b/source/snes9x/snes9x.h
@@ -58,8 +58,6 @@
 #define SNES_HEIGHT_EXTENDED		239
 #define MAX_SNES_WIDTH				(SNES_WIDTH * 2)
 #define MAX_SNES_HEIGHT				(SNES_HEIGHT_EXTENDED * 2)
-#define IMAGE_WIDTH					(Settings.SupportHiRes ? MAX_SNES_WIDTH : SNES_WIDTH)
-#define IMAGE_HEIGHT				(Settings.SupportHiRes ? MAX_SNES_HEIGHT : SNES_HEIGHT_EXTENDED)
 
 #define	NTSC_MASTER_CLOCK			21477272.727272 // 21477272 + 8/11 exact
 #define	PAL_MASTER_CLOCK			21281370.0
@@ -241,7 +239,6 @@ struct SSettings
 	bool8	DynamicRateControl;
 	int32	InterpolationMethod;
 
-	bool8	SupportHiRes;
 	bool8	Transparency;
 	uint8	BG_Forced;
 	bool8	DisableGraphicWindows;
@@ -302,7 +299,6 @@ struct SSettings
 	bool8	DontSaveOopsSnapshot;
 	bool8	UpAndDown;
 
-	bool8	OpenGLEnable;
 	float	SuperFXSpeedPerLine;
 
 	bool8   SeparateEchoBuffer;

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -377,7 +377,6 @@ void InitializeSnes9x() {
 	S9xInitSound (64, 0); // Initialise Sound System
 
 	// Initialise Graphics
-	setGFX ();
 	if (!S9xGraphicsInit ())
 		ExitApp();
 

--- a/source/video.cpp
+++ b/source/video.cpp
@@ -34,7 +34,7 @@
 extern void UpdatePlaybackRate(void);
 
 /*** Snes9x GFX Buffer ***/
-#define SNES9XGFX_SIZE 		(EXT_PITCH*EXT_HEIGHT)
+#define SNES9XGFX_SIZE 		(GFX.Pitch*MAX_SNES_HEIGHT)
 #define FILTERMEM_SIZE 		(512*MAX_SNES_HEIGHT*4)
 
 static unsigned char * snes9xgfx = NULL;
@@ -828,7 +828,7 @@ update_video (int width, int height)
 	// convert image to texture
 	if (GCSettings.FilterMethod != FILTER_NONE && vheight <= 239 && vwidth <= 256)	// don't do filtering on game textures > 256 x 239
 	{
-		FilterMethod ((uint8*) GFX.Screen, EXT_PITCH, (uint8*) filtermem, vwidth*fscale*2, vwidth, vheight);
+		FilterMethod ((uint8*) GFX.Screen, GFX.Pitch, (uint8*) filtermem, vwidth*fscale*2, vwidth, vheight);
 		MakeTexture565((char *) filtermem, (char *) texturemem, vwidth*fscale, vheight*fscale);
 	}
 	else
@@ -883,19 +883,7 @@ void AllocGfxMem()
 	memset(filtermem, 0, FILTERMEM_SIZE);
 #endif
 
-	GFX.Pitch = EXT_PITCH;
-	GFX.Screen = (uint16*)(snes9xgfx + EXT_OFFSET);
-}
-
-/****************************************************************************
- * setGFX
- *
- * Setup the global GFX information for Snes9x
- ***************************************************************************/
-void
-setGFX ()
-{
-	GFX.Pitch = EXT_PITCH;
+	GFX.Screen = (uint16*)(snes9xgfx + (GFX.Pitch * 2 + 2 * 2));
 }
 
 /****************************************************************************

--- a/source/video.h
+++ b/source/video.h
@@ -21,7 +21,6 @@ void AllocGfxMem();
 void InitGCVideo ();
 void StopGX();
 void ResetVideo_Emu();
-void setGFX();
 void update_video (int width, int height);
 void ResetVideo_Menu();
 void TakeScreenshot();

--- a/source/xenon/main.cpp
+++ b/source/xenon/main.cpp
@@ -289,8 +289,7 @@ int main(void)
 	S9xInitSound (5, TRUE, 1024);
 
 	// Initialise Graphics
-		
-//	setGFX ();
+
 	videoInit();
 	
 	if (!S9xGraphicsInit ())


### PR DESCRIPTION
@dborth this combines multiple changes in one, I'm not able to test this please test the file before committing it.

Snes9x - Create output buffer in core.
Snes9x - libretro: Fix audio when video rendering is disabled
Snes9x - Use MAX_SNES_HEIGHT, not SNES_HEIGHT_EXTENDED.
Snes9x - Remove Settings.SupportHires

Thanks in advance.