### PR TITLE
Snes9x - Add option for overclock Super FX at 20 MHz and update selectable options (Taken from niuus' Snes9x RX)

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3484,14 +3484,15 @@ static int MenuSettingsVideo()
 				break;
 			case 9:
 				GCSettings.sfxOverclock++;
-				if (GCSettings.sfxOverclock > 2) {
+				if (GCSettings.sfxOverclock > 3) {
 					GCSettings.sfxOverclock = 0;
 				}
 				switch(GCSettings.sfxOverclock)
 				{
 					case 0: Settings.SuperFXSpeedPerLine = 5823405; break;
-					case 1: Settings.SuperFXSpeedPerLine = 0.417 * 40.5e6; break;
-					case 2: Settings.SuperFXSpeedPerLine = 0.417 * 60.5e6; break;
+					case 1: Settings.SuperFXSpeedPerLine = 0.417 * 20.5e6; break;
+					case 2: Settings.SuperFXSpeedPerLine = 0.417 * 40.5e6; break;
+					case 3: Settings.SuperFXSpeedPerLine = 0.417 * 60.5e6; break;
 				}
 				S9xResetSuperFX();
 				S9xReset();
@@ -3544,9 +3545,11 @@ static int MenuSettingsVideo()
 				case 0:
 					sprintf (options.value[9], "Default"); break;
 				case 1:
-					sprintf (options.value[9], "40 MHz"); break;
+					sprintf (options.value[8], "20 MHz"); break;
 				case 2:
-					sprintf (options.value[9], "60 MHz"); break;
+					sprintf (options.value[8], "40 MHz"); break;
+				case 3:
+					sprintf (options.value[8], "60 MHz"); break;
 			}
 			optionBrowser.TriggerUpdate();
 		}

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3545,11 +3545,11 @@ static int MenuSettingsVideo()
 				case 0:
 					sprintf (options.value[9], "Default"); break;
 				case 1:
-					sprintf (options.value[8], "20 MHz"); break;
+					sprintf (options.value[9], "20 MHz"); break;
 				case 2:
-					sprintf (options.value[8], "40 MHz"); break;
+					sprintf (options.value[9], "40 MHz"); break;
 				case 3:
-					sprintf (options.value[8], "60 MHz"); break;
+					sprintf (options.value[9], "60 MHz"); break;
 			}
 			optionBrowser.TriggerUpdate();
 		}

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -482,8 +482,9 @@ int main(int argc, char *argv[])
 	switch (GCSettings.sfxOverclock)
 	{
 		case 0: Settings.SuperFXSpeedPerLine = 5823405; break;
-		case 1: Settings.SuperFXSpeedPerLine = 0.417 * 40.5e6; break;
-		case 2: Settings.SuperFXSpeedPerLine = 0.417 * 60.5e6; break;
+		case 1: Settings.SuperFXSpeedPerLine = 0.417 * 20.5e6; break;
+		case 2: Settings.SuperFXSpeedPerLine = 0.417 * 40.5e6; break;
+		case 3: Settings.SuperFXSpeedPerLine = 0.417 * 60.5e6; break;
 	}
 
 	if (GCSettings.sfxOverclock > 0)


### PR DESCRIPTION
This intends to add a selectable option for overclock Super FX 1 / GSU-1 (MARIO Chip) games to 20 MHz, taken from @niuus' fork of Snes9x GX, called [Snes9x RX](http://github.com/niuus/Snes9xRX).

Most SNES emulators currently have options to overclock the Super FX chip to 40MHz, 60MHz, 80MHz, and 100MHz. This makes many games (Star Fox is the common example) play much faster than intended.
I decided to add this since overclocking Super FX GSU-1 games to 40 MHz/60 MHz are unstable, making it unplayable due to too fast speed, so this modification adds this 20MHz overclock option, with the goal of the SFX GSU-1 games to receive a reasonable, playable speedup.

[This linked video](https://www.youtube.com/watch?v=3gVg8vDhfQk) demonstrates the output of libretro-snes9x with snes9x_overclock set to disabled, 20MHz (new), and 40MHz, respectively.
Even when shows from RetroArch, i tested this in my build with this mod and looks like it works as intended. But it still needs a little testing.
**EDIT: Tested again with a few SFX GSU-1 games and working as a charm.**