### PR TITLE
Add option to toggle the Turbo Mode feature on/off

### DIFF
--- a/source/input.cpp
+++ b/source/input.cpp
@@ -747,12 +747,15 @@ void ReportButtons ()
 
 	UpdatePads();
 
-	Settings.TurboMode = (
-		userInput[0].pad.substickX > 70 ||
-		userInput[0].WPAD_StickX(1) > 70 ||
-		userInput[0].wiidrcdata.substickX > 45
-	);	// RIGHT on c-stick and on classic controller right joystick
-
+	if (GCSettings.TurboModeEnabled == 1)
+	{
+		Settings.TurboMode = (
+			userInput[0].pad.substickX > 70 ||
+			userInput[0].WPAD_StickX(1) > 70 ||
+			userInput[0].wiidrcdata.substickX > 45
+		);	// RIGHT on c-stick and on classic controller right joystick
+	}
+	
 	if(Settings.TurboMode) {
 		Settings.SoundSync = false;
 	}

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3389,6 +3389,7 @@ static int MenuSettingsVideo()
 	sprintf(options.name[i++], "Show Framerate");
 	sprintf(options.name[i++], "Show Local Time");
 	sprintf(options.name[i++], "SuperFX Overclock");
+	sprintf(options.name[i++], "Fast Forward");
 	options.length = i;
 	
 #ifdef HW_DOL
@@ -3497,6 +3498,11 @@ static int MenuSettingsVideo()
 				S9xResetSuperFX();
 				S9xReset();
 				break;
+			case 10:
+				GCSettings.TurboModeEnabled++;
+				if (GCSettings.TurboModeEnabled > 1)
+					GCSettings.TurboModeEnabled = 0;
+				break;
 		}
 
 		if(ret >= 0 || firstRun)
@@ -3551,6 +3557,7 @@ static int MenuSettingsVideo()
 				case 3:
 					sprintf (options.value[9], "60 MHz"); break;
 			}
+			sprintf (options.value[10], "%s", GCSettings.TurboModeEnabled == 1 ? "On" : "Off");
 			optionBrowser.TriggerUpdate();
 		}
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3389,7 +3389,7 @@ static int MenuSettingsVideo()
 	sprintf(options.name[i++], "Show Framerate");
 	sprintf(options.name[i++], "Show Local Time");
 	sprintf(options.name[i++], "SuperFX Overclock");
-	sprintf(options.name[i++], "Fast Forward");
+	sprintf(options.name[i++], "Enable Turbo Mode");
 	options.length = i;
 	
 #ifdef HW_DOL

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -154,6 +154,7 @@ preparePrefsData ()
 	createXMLSetting("yshift", "Vertical Video Shift", toStr(GCSettings.yshift));
 	createXMLSetting("sfxOverclock", "SuperFX Overclock", toStr(GCSettings.sfxOverclock));
 	createXMLSetting("Interpolation", "Interpolation", toStr(GCSettings.Interpolation));
+	createXMLSetting("TurboModeEnabled", "Turbo Mode Enabled", toStr(GCSettings.TurboModeEnabled));
 
 	createXMLSection("Menu", "Menu Settings");
 
@@ -337,6 +338,7 @@ decodePrefsData ()
 			loadXMLSetting(&GCSettings.FilterMethod, "FilterMethod");
 			loadXMLSetting(&GCSettings.xshift, "xshift");
 			loadXMLSetting(&GCSettings.yshift, "yshift");
+			loadXMLSetting(&GCSettings.TurboModeEnabled, "TurboModeEnabled");
 			
 			// Audio Settings
 			
@@ -529,6 +531,8 @@ DefaultSettings ()
 	Settings.OneClockCycle = 6;
 	Settings.OneSlowClockCycle = 8;
 	Settings.TwoClockCycles = 12;
+
+	GCSettings.TurboModeEnabled = 1; // Enabled by default
 }
 
 /****************************************************************************

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -120,8 +120,10 @@ struct SGCSettings{
 	int		PreviewImage;
 
 	int		sfxOverclock;
-	
+
 	int		Interpolation;
+
+	int     TurboModeEnabled; // 0 - disabled, 1 - enabled
 };
 
 void ExitApp();

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -120,10 +120,10 @@ struct SGCSettings{
 	int		PreviewImage;
 
 	int		sfxOverclock;
-
+	
 	int		Interpolation;
 
-	int     TurboModeEnabled; // 0 - disabled, 1 - enabled
+	int		TurboModeEnabled; // 0 - disabled, 1 - enabled
 };
 
 void ExitApp();

--- a/source/xenon/s9xconfig.cpp
+++ b/source/xenon/s9xconfig.cpp
@@ -90,6 +90,7 @@ DefaultSettings ()
 	GCSettings.MusicVolume = 40;
 	GCSettings.SFXVolume = 40;
 	GCSettings.Rumble = 1;
+	GCSettings.TurboModeEnabled = 1; // Enabled by default
 #endif
 
 	/****************** SNES9x Settings ***********************/


### PR DESCRIPTION
These changes added an option to the Video Settings menu to toggle on/off the "Turbo Mode" feature from the right analog stick. When disabled, holding the stick to the right does not activate Turbo Mode. The setting is enabled by default.

The setting is saved to XML and the user's choice persists upon application re-entry.