### PR TITLE
Add a toggle to hide/show the SRAM save button in the save menu UI (InfiniteBlueGX)

### DIFF
--- a/source/gui/gui_savebrowser.cpp
+++ b/source/gui/gui_savebrowser.cpp
@@ -323,21 +323,27 @@ void GuiSaveBrowser::Update(GuiTrigger * t)
 	{
 		if(listOffset+i < 0 && action == 1)
 		{
+
 			saveDate[0]->SetText(NULL);
-			saveDate[1]->SetText(NULL);
 			saveTime[0]->SetText("New");
-			saveTime[1]->SetText("New");
-			saveType[0]->SetText("SRAM");
-			saveType[1]->SetText("State");
+			saveType[0]->SetText("State");
 			savePreviewImg[0]->SetImage(gameSaveBlank);
-			savePreviewImg[1]->SetImage(gameSaveBlank);
 			saveBtn[0]->SetVisible(true);
-			saveBtn[1]->SetVisible(true);
 
 			if(saveBtn[0]->GetState() == STATE_DISABLED)
 				saveBtn[0]->SetState(STATE_DEFAULT);
-			if(saveBtn[1]->GetState() == STATE_DISABLED)
-				saveBtn[1]->SetState(STATE_DEFAULT);
+			
+			if (GCSettings.HideSRAMSaving == 0)
+			{
+				saveDate[1]->SetText(NULL);
+				saveTime[1]->SetText("New");
+				saveType[1]->SetText("SRAM");
+				savePreviewImg[1]->SetImage(gameSaveBlank);
+				saveBtn[1]->SetVisible(true);
+
+				if(saveBtn[1]->GetState() == STATE_DISABLED)
+					saveBtn[1]->SetState(STATE_DEFAULT);
+			}
 		}
 		else if(listOffset+i < saves->length)
 		{

--- a/source/lang/es.lang
+++ b/source/lang/es.lang
@@ -265,6 +265,9 @@ msgstr "Alemán"
 msgid "Go Back"
 msgstr "Volver"
 
+msgid "Hide SRAM Saving"
+msgstr "Esconder Guardar SRAM"
+
 msgid "Horizontal"
 msgstr "Horizontal"
 

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -1987,20 +1987,7 @@ static int MenuGameSaves(int action)
 			}
 			else // save
 			{
-				if(ret == -2) // new SRAM
-				{
-					for(i=1; i < 100; i++)
-						if(saves.files[FILE_SRAM][i] == 0)
-							break;
-
-					if(i < 100)
-					{
-						MakeFilePath(filepath, FILE_SRAM, Memory.ROMFilename, i);
-						SaveSRAM(filepath, NOTSILENT);
-						menu = MENU_GAME_SAVE;
-					}
-				}
-				else if(ret == -1) // new State
+				if(ret == -2) // new State
 				{
 					for(i=1; i < 100; i++)
 						if(saves.files[FILE_SNAPSHOT][i] == 0)
@@ -2009,7 +1996,20 @@ static int MenuGameSaves(int action)
 					if(i < 100)
 					{
 						MakeFilePath(filepath, FILE_SNAPSHOT, Memory.ROMFilename, i);
-						SaveSnapshot (filepath, NOTSILENT);
+						SaveSnapshot(filepath, NOTSILENT);
+						menu = MENU_GAME_SAVE;
+					}
+				}
+				else if(ret == -1 && GCSettings.HideSRAMSaving == 0) // new SRAM
+				{
+					for(i=1; i < 100; i++)
+						if(saves.files[FILE_SRAM][i] == 0)
+							break;
+
+					if(i < 100)
+					{
+						MakeFilePath(filepath, FILE_SRAM, Memory.ROMFilename, i);
+						SaveSRAM (filepath, NOTSILENT);
 						menu = MENU_GAME_SAVE;
 					}
 				}
@@ -4232,6 +4232,7 @@ static int MenuSettingsMenu()
 	sprintf(options.name[i++], "Rumble");
 	sprintf(options.name[i++], "Language");
 	sprintf(options.name[i++], "Preview Image");
+	sprintf(options.name[i++], "Hide SRAM Saving");
 	options.length = i;
 
 	for(i=0; i < options.length; i++)
@@ -4317,6 +4318,9 @@ static int MenuSettingsMenu()
 				if(GCSettings.PreviewImage > 2)
 					GCSettings.PreviewImage = 0;
 				break;
+			case 7:
+				GCSettings.HideSRAMSaving ^= 1;
+				break;
 		}
 
 		if(ret >= 0 || firstRun)
@@ -4365,6 +4369,11 @@ static int MenuSettingsMenu()
 				sprintf (options.value[4], "Enabled");
 			else
 				sprintf (options.value[4], "Disabled");
+			
+			if (GCSettings.HideSRAMSaving == 1)
+				sprintf (options.value[7], "On");
+			else
+				sprintf (options.value[7], "Off");
 
 			switch(GCSettings.language)
 			{

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -168,6 +168,7 @@ preparePrefsData ()
 	createXMLSetting("Rumble", "Rumble", toStr(GCSettings.Rumble));
 	createXMLSetting("language", "Language", toStr(GCSettings.language));
 	createXMLSetting("PreviewImage", "Preview Image", toStr(GCSettings.PreviewImage));
+	createXMLSetting("HideSRAMSaving", "Hide SRAM Saving", toStr(GCSettings.HideSRAMSaving));
 	
 	createXMLSection("Controller", "Controller Settings");
 
@@ -359,6 +360,7 @@ decodePrefsData ()
 			loadXMLSetting(&GCSettings.Rumble, "Rumble");
 			loadXMLSetting(&GCSettings.language, "language");
 			loadXMLSetting(&GCSettings.PreviewImage, "PreviewImage");
+			loadXMLSetting(&GCSettings.HideSRAMSaving, "HideSRAMSaving");
 
 			// Controller Settings
 
@@ -466,6 +468,7 @@ DefaultSettings ()
 	GCSettings.SFXVolume = 40;
 	GCSettings.Rumble = 1;
 	GCSettings.PreviewImage = 0;
+	GCSettings.HideSRAMSaving = 0;
 	
 #ifdef HW_RVL
 	GCSettings.language = CONF_GetLanguage();

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -112,6 +112,7 @@ struct SGCSettings{
 	char	ScreenshotsFolder[MAXPATHLEN]; // Path to screenshots files
 	char	CoverFolder[MAXPATHLEN]; 	// Path to cover files
 	char	ArtworkFolder[MAXPATHLEN]; 	// Path to artwork files
+	int		HideSRAMSaving;
 	int		AutoloadGame;
 
 	char	smbip[80];


### PR DESCRIPTION
Some games doesn't have a SRAM saving function, and some people doesn't want much saving manually the SRAM since Snes9x GX does it automatically, so this modification adds a toggle for hide/show the SRAM save button on the save menu UI.

Based on @InfiniteBlueGX's code.