### PR TITLE
Snes9x - forgot to fix something of SuperFX overclock saving (Tanooki16)

### DIFF
--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -514,7 +514,6 @@ int main(int argc, char *argv[])
 
 			if (GCSettings.sfxOverclock > 0)
 			S9xResetSuperFX();
-			else
 			S9xReset();
 
 			switch (GCSettings.Interpolation)


### PR DESCRIPTION
When i was doing this PR https://github.com/dborth/snes9xgx/pull/1008, i forgot to see about the bug of most SNES games which are not Super FX when not using overclock causing the game to reset when coming back from menu.

Checking @Tanooki16's modified code again, i saw that there was something that mustn't be here.
This fixes that bug mentioned.
(See https://gbatemp.net/threads/snes9x-gx-4-4-0-beta-feedback-requested.521929/post-9828879)

Thanks to @Tanooki16 (author of Snes9x TX) for this small fix.