### PR TITLE
Disabled peripheral devices by default if not selected in controller settings (Tanooki16)

### DIFF
--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -486,10 +486,10 @@ DefaultSettings ()
 
 	// General
 
-	Settings.MouseMaster = true;
-	Settings.SuperScopeMaster = true;
-	Settings.JustifierMaster = true;
-	Settings.MultiPlayer5Master = true;
+	Settings.MouseMaster = false;
+	Settings.SuperScopeMaster = false;
+	Settings.JustifierMaster = false;
+	Settings.MultiPlayer5Master = false;
 	Settings.DontSaveOopsSnapshot = true;
 	Settings.ApplyCheats = true;
 


### PR DESCRIPTION
If the peripheral devices (Super Scope, SNES Mouse, Justifier, Multi-tap for 5 players) are not selected in the Settings, then disable them by default.

Taken from Snes9x TX from Tanooki16.