### PR TITLE
SNES Hi-Res Mode ON/OFF and Sprite Limit ON/OFF (Tanooki16)

### DIFF
--- a/source/lang/es.lang
+++ b/source/lang/es.lang
@@ -794,7 +794,7 @@ msgid "SNES Controllers (4)"
 msgstr "Controles de SNES (4)"
 
 msgid "SNES Hi-Res Mode"
-msgstr "Modo Alto-Res SNES"
+msgstr "Modo Alta-Res SNES"
 
 msgid "SNES Mouse"
 msgstr "Mouse de SNES"

--- a/source/lang/es.lang
+++ b/source/lang/es.lang
@@ -793,11 +793,17 @@ msgstr "Controles de SNES (2)"
 msgid "SNES Controllers (4)"
 msgstr "Controles de SNES (4)"
 
+msgid "SNES Hi-Res Mode"
+msgstr "Modo Alto-Res SNES"
+
 msgid "SNES Mouse"
 msgstr "Mouse de SNES"
 
 msgid "Snes9x - Copyright (c) Snes9x Team 1996 - 2022"
 msgstr "Snes9x - Derechos de autor (c) Snes9x Team 1996 - 2022"
+
+msgid "Sprites per-line Limit"
+msgstr "Límite de Sprites"
 
 msgid "SRAM"
 msgstr "SRAM"

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3536,8 +3536,10 @@ static int MenuSettingsVideo()
 	sprintf(options.name[i++], "Filtering");
 	sprintf(options.name[i++], "Screen Zoom");
 	sprintf(options.name[i++], "Screen Position");
-	sprintf(options.name[i++], "Crosshair");
 	sprintf(options.name[i++], "Video Mode");
+	sprintf(options.name[i++], "SNES Hi-Res Mode");
+	sprintf(options.name[i++], "Sprites per-line Limit");
+	sprintf(options.name[i++], "Crosshair");
 	sprintf(options.name[i++], "Show Framerate");
 	sprintf(options.name[i++], "Show Local Time");
 	sprintf(options.name[i++], "SuperFX Overclock");
@@ -3620,21 +3622,32 @@ static int MenuSettingsVideo()
 				break;
 
 			case 5:
-				GCSettings.crosshair ^= 1;
-				break;
-
-			case 6:
 				GCSettings.videomode++;
 				if(GCSettings.videomode > 4)
 					GCSettings.videomode = 0;
 				break;
+				
+			case 6:
+				GCSettings.HiResolution ^= 1;
+				break;
+				
 			case 7:
+				GCSettings.SpriteLimit ^= 1;
+				break;
+
+			case 8:
+				GCSettings.crosshair ^= 1;
+				break;
+				
+			case 9:
 				Settings.DisplayFrameRate ^= 1;
 				break;
-			case 8:
+				
+			case 10:
 				Settings.DisplayTime ^= 1;
 				break;
-			case 9:
+				
+			case 11:
 				#ifdef HW_RVL
 				GCSettings.sfxOverclock++;
 				if (GCSettings.sfxOverclock > 6) {
@@ -3685,39 +3698,41 @@ static int MenuSettingsVideo()
 #endif
 			sprintf (options.value[3], "%.2f%%, %.2f%%", GCSettings.zoomHor*100, GCSettings.zoomVert*100);
 			sprintf (options.value[4], "%d, %d", GCSettings.xshift, GCSettings.yshift);
-			sprintf (options.value[5], "%s", GCSettings.crosshair == 1 ? "On" : "Off");
 
 			switch(GCSettings.videomode)
 			{
 				case 0:
-					sprintf (options.value[6], "Automatic (Recommended)"); break;
+					sprintf (options.value[5], "Automatic (Recommended)"); break;
 				case 1:
-					sprintf (options.value[6], "NTSC (480i)"); break;
+					sprintf (options.value[5], "NTSC (480i)"); break;
 				case 2:
-					sprintf (options.value[6], "Progressive (480p)"); break;
+					sprintf (options.value[5], "Progressive (480p)"); break;
 				case 3:
-					sprintf (options.value[6], "PAL (50Hz)"); break;
+					sprintf (options.value[5], "PAL (50Hz)"); break;
 				case 4:
-					sprintf (options.value[6], "PAL (60Hz)"); break;
+					sprintf (options.value[5], "PAL (60Hz)"); break;
 			}
-			sprintf (options.value[7], "%s", Settings.DisplayFrameRate ? "On" : "Off");
-			sprintf (options.value[8], "%s", Settings.DisplayTime ? "On" : "Off");
+			sprintf (options.value[6], "%s", GCSettings.HiResolution == 1 ? "On" : "Off");
+			sprintf (options.value[7], "%s", GCSettings.SpriteLimit == 1 ? "On" : "Off");
+			sprintf (options.value[8], "%s", GCSettings.crosshair == 1 ? "On" : "Off");
+			sprintf (options.value[9], "%s", Settings.DisplayFrameRate ? "On" : "Off");
+			sprintf (options.value[10], "%s", Settings.DisplayTime ? "On" : "Off");
 			switch(GCSettings.sfxOverclock)
 			{
 				case 0:
-					sprintf (options.value[9], "Default"); break;
+					sprintf (options.value[11], "Default"); break;
 				case 1:
-					sprintf (options.value[9], "20 MHz"); break;
+					sprintf (options.value[11], "20 MHz"); break;
 				case 2:
-					sprintf (options.value[9], "40 MHz"); break;
+					sprintf (options.value[11], "40 MHz"); break;
 				case 3:
-					sprintf (options.value[9], "60 MHz"); break;
+					sprintf (options.value[11], "60 MHz"); break;
 				case 4:
-					sprintf (options.value[9], "80 MHz"); break;
+					sprintf (options.value[11], "80 MHz"); break;
 				case 5:
-					sprintf (options.value[9], "100 MHz"); break;
+					sprintf (options.value[11], "100 MHz"); break;
 				case 6:
-					sprintf (options.value[9], "120 MHz"); break;
+					sprintf (options.value[11], "120 MHz"); break;
 			}
 			optionBrowser.TriggerUpdate();
 		}

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -150,6 +150,8 @@ preparePrefsData ()
 	createXMLSetting("widescreen", "Aspect Ratio Correction", toStr(GCSettings.widescreen));
 	createXMLSetting("crosshair", "Crosshair", toStr(GCSettings.crosshair));
 	createXMLSetting("FilterMethod", "Filter Method", toStr(GCSettings.FilterMethod));
+	createXMLSetting("HiResolution", "SNES Hi-Res Mode", toStr(GCSettings.HiResolution));
+	createXMLSetting("SpriteLimit", "Sprites per-line Limit", toStr(GCSettings.SpriteLimit));
 	createXMLSetting("xshift", "Horizontal Video Shift", toStr(GCSettings.xshift));
 	createXMLSetting("yshift", "Vertical Video Shift", toStr(GCSettings.yshift));
 	createXMLSetting("sfxOverclock", "SuperFX Overclock", toStr(GCSettings.sfxOverclock));
@@ -338,6 +340,8 @@ decodePrefsData ()
 			loadXMLSetting(&GCSettings.widescreen, "widescreen");
 			loadXMLSetting(&GCSettings.crosshair, "crosshair");
 			loadXMLSetting(&GCSettings.FilterMethod, "FilterMethod");
+			loadXMLSetting(&GCSettings.HiResolution, "HiResolution");
+			loadXMLSetting(&GCSettings.SpriteLimit, "SpriteLimit");
 			loadXMLSetting(&GCSettings.xshift, "xshift");
 			loadXMLSetting(&GCSettings.yshift, "yshift");
 			loadXMLSetting(&GCSettings.TurboModeEnabled, "TurboModeEnabled");
@@ -514,14 +518,15 @@ DefaultSettings ()
 
 	// Graphics
 	Settings.Transparency = true;
-	Settings.SupportHiRes = true;
 	Settings.MaxSpriteTilesPerLine = 34;
 	Settings.SkipFrames = AUTO_FRAMERATE;
 	Settings.TurboSkipFrames = 19;
-	Settings.DisplayFrameRate = false;
 	Settings.AutoDisplayMessages = false;
 	Settings.InitialInfoStringTimeout = 200; // # frames to display messages for
+	Settings.DisplayFrameRate = false;
 	Settings.DisplayTime = false;
+	GCSettings.HiResolution = 1; // Enabled by default
+	GCSettings.SpriteLimit = 1; // Enabled by default
 
 	// Frame timings in 50hz and 60hz cpu mode
 	Settings.FrameTimePAL = 20000;

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -531,6 +531,8 @@ int main(int argc, char *argv[])
 		ScreenshotRequested = 0;
 		SwitchAudioMode(0);
 
+		Settings.SupportHiRes = (GCSettings.HiResolution == 1);
+		Settings.MaxSpriteTilesPerLine = (GCSettings.SpriteLimit ? 34 : 128);
 		Settings.AutoDisplayMessages = (Settings.DisplayFrameRate || Settings.DisplayTime ? true : false);
 		Settings.MultiPlayer5Master = (GCSettings.Controller == CTRL_PAD4 ? true : false);
 		Settings.SuperScopeMaster = (GCSettings.Controller == CTRL_SCOPE ? true : false);

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -126,6 +126,8 @@ struct SGCSettings{
 	int		render;		// 0 - original, 1 - filtered, 2 - unfiltered
 	int		FilterMethod; // convert to RenderFilter
 	int		Controller;
+	int		HiResolution;
+	int		SpriteLimit;
 	int		crosshair;
 	int		widescreen;	// 0 - 4:3 aspect, 1 - 16:9 aspect
 	int		xshift;	// video output shift


### PR DESCRIPTION
This changes adds a toggle for turn On/Off the Hi-Resolution mode, and another toggle for turn On/Off the sprite limit.

The first one allows you to disable the high resolution of the games that use this mode to make them compatible with the video filters.

The second one is to disable the sprite limit. (useful for reducing some glitches and even remove slowdown on some games, for example Super Aleste (official) and the hack [Final Fight 2 Readjusted](https://www.romhacking.net/hacks/6671/) (hack of Final Fight 2 for have 5 enemies spawned, rather than 3).

A test of the Super Aleste game with sprite limit and without it:

With

![image](https://user-images.githubusercontent.com/66485640/176314767-4632cb64-d92d-4639-a1bc-8dddba1da99a.png)

Without

![image](https://user-images.githubusercontent.com/66485640/176314801-a5384c20-163e-4f20-9204-69f97c5baf53.png)

Taken also from Snes9x TX by Tanooki16.