### PR TITLE
Fix bug where Save SRAM button could be focused when disabled

### DIFF
--- a/source/gui/gui_savebrowser.cpp
+++ b/source/gui/gui_savebrowser.cpp
@@ -269,7 +269,10 @@ void GuiSaveBrowser::Update(GuiTrigger * t)
 		}
 		else
 		{
-			selectedItem -= 1;
+			if(saveBtn[selectedItem-1]->IsVisible())
+			{
+				selectedItem -= 1;
+			}
 		}
 	}
 	else if(t->Down() || arrowDownBtn->GetState() == STATE_CLICKED)
@@ -307,7 +310,10 @@ void GuiSaveBrowser::Update(GuiTrigger * t)
 		}
 		else
 		{
-			selectedItem -= 2;
+			if(saveBtn[selectedItem-2]->IsVisible())
+			{
+				selectedItem -= 2;
+			}
 		}
 	}
 


### PR DESCRIPTION
When the "Hide SRAM" option was enabled, the "New SRAM" button would be hidden and disabled, however, it could still be focused upon despite being invisible. This commit fixes the problem.

@dborth , would it be worthwhile if I brought this feature over to FCEUGX? I only really use Snes9xGX but I'd be able to port it over there if there's a desire for feature parity. 