### PR TITLE
Add a couple new controller remapping options

### DIFF
--- a/source/input.cpp
+++ b/source/input.cpp
@@ -590,6 +590,50 @@ static void decodepad (int chan, int emuChan)
 		wiidrcp |= WIIDRC_BUTTON_RIGHT;
 #endif
 
+	if (GCSettings.MapABXYRightStick == 1)
+	{
+		s8 pad_substickX = userInput[chan].pad.substickX;
+		s8 pad_substickY = userInput[chan].pad.substickY;
+#ifdef HW_RVL
+		s8 wm_substickX = userInput[chan].WPAD_StickX(1);
+		s8 wm_substickY = userInput[chan].WPAD_StickY(1);
+		s16 wiidrc_substickX = userInput[chan].wiidrcdata.substickX;
+		s16 wiidrc_substickY = userInput[chan].wiidrcdata.substickY;
+#endif
+
+		/* Gamecube Controller */
+		if (pad_substickY > ANALOG_SENSITIVITY)
+			jp |= PAD_BUTTON_X;
+		else if (pad_substickY < -ANALOG_SENSITIVITY)
+			jp |= PAD_BUTTON_B;
+		if (pad_substickX < -ANALOG_SENSITIVITY)
+			jp |= PAD_BUTTON_Y;
+		else if (pad_substickX > ANALOG_SENSITIVITY)
+			jp |= PAD_BUTTON_A;
+
+#ifdef HW_RVL
+		/* Wii Controller */
+		if (wm_substickY > ANALOG_SENSITIVITY)
+			wp |= WPAD_CLASSIC_BUTTON_X;
+		else if (wm_substickY < -ANALOG_SENSITIVITY)
+			wp |= WPAD_CLASSIC_BUTTON_B;
+		if (wm_substickX < -ANALOG_SENSITIVITY)
+			wp |= WPAD_CLASSIC_BUTTON_Y;
+		else if (wm_substickX > ANALOG_SENSITIVITY)
+			wp |= WPAD_CLASSIC_BUTTON_A;
+
+		/* Wii U Gamepad */
+		if (wiidrc_substickY > ANALOG_SENSITIVITY)
+			wiidrcp |= WIIDRC_BUTTON_X;
+		else if (wiidrc_substickY < -ANALOG_SENSITIVITY)
+			wiidrcp |= WIIDRC_BUTTON_B;
+		if (wiidrc_substickX < -ANALOG_SENSITIVITY)
+			wiidrcp |= WIIDRC_BUTTON_Y;
+		else if (wiidrc_substickX > ANALOG_SENSITIVITY)
+			wiidrcp |= WIIDRC_BUTTON_A;
+#endif
+	}
+
 	/*** Fix offset to pad ***/
 	offset = ((emuChan + 1) << 4);
 

--- a/source/input.cpp
+++ b/source/input.cpp
@@ -714,23 +714,58 @@ bool MenuRequested()
 {
 	for(int i=0; i<4; i++)
 	{
-		if (
-			(userInput[i].pad.substickX < -70) ||
-			(userInput[i].pad.btns_h & PAD_TRIGGER_L &&
-			userInput[i].pad.btns_h & PAD_TRIGGER_R &&
-			userInput[i].pad.btns_h & PAD_BUTTON_START)
-			#ifdef HW_RVL
-			|| (userInput[i].wpad->btns_h & WPAD_BUTTON_HOME) ||
-			(userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_HOME) ||
-			(userInput[i].wiidrcdata.btns_h & WIIDRC_BUTTON_HOME) ||
-			(userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_L &&
-			userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_R &&
-			userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_PLUS)
-			#endif
-		)
+		if (GCSettings.GamepadMenuToggle == 1) // Home (WiiPad) or Right Stick (GC/3rd party gamepad) only
 		{
-			return true;
+			if (
+				(userInput[i].pad.substickX < -70)
+				#ifdef HW_RVL
+				|| (userInput[i].wpad->btns_h & WPAD_BUTTON_HOME) ||
+				(userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_HOME) ||
+				(userInput[i].wiidrcdata.btns_h & WIIDRC_BUTTON_HOME)
+				#endif
+			)
+			{
+				return true;
+			}
 		}
+		else if (GCSettings.GamepadMenuToggle == 2) // L+R+Start combo only (frees up the right stick on GC/3rd party gamepad)
+		{
+			if (
+				(userInput[i].pad.btns_h & PAD_TRIGGER_L &&
+				userInput[i].pad.btns_h & PAD_TRIGGER_R &&
+				userInput[i].pad.btns_h & PAD_BUTTON_START)
+				#ifdef HW_RVL
+				|| (userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_L &&
+				userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_R &&
+				userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_PLUS)
+				#endif
+			)
+			{
+				return true;
+			}
+		}
+		else // All toggle options enabled
+		{
+			if (
+				(userInput[i].pad.substickX < -70) ||
+				(userInput[i].pad.btns_h & PAD_TRIGGER_L &&
+				userInput[i].pad.btns_h & PAD_TRIGGER_R &&
+				userInput[i].pad.btns_h & PAD_BUTTON_START)
+				#ifdef HW_RVL
+				|| (userInput[i].wpad->btns_h & WPAD_BUTTON_HOME) ||
+				(userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_HOME) ||
+				(userInput[i].wiidrcdata.btns_h & WIIDRC_BUTTON_HOME) ||
+				(userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_L &&
+				userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_R &&
+				userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_PLUS)
+				#endif
+			)
+			{
+				return true;
+			}
+		}
+
+		
 	}
 	return false;
 }

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3404,6 +3404,7 @@ static int MenuSettingsOtherMappings()
 	sprintf(options.name[i++], "Enable Turbo Mode");
 	sprintf(options.name[i++], "Turbo Mode Button");
 	sprintf(options.name[i++], "Menu Toggle");
+	sprintf(options.name[i++], "Map ABXY to Right Stick");
 
 	options.length = i;
 
@@ -3475,6 +3476,10 @@ static int MenuSettingsOtherMappings()
 				if (GCSettings.GamepadMenuToggle > 2)
 					GCSettings.GamepadMenuToggle = 0;
 				break;
+
+			case 3:
+				GCSettings.MapABXYRightStick ^= 1;
+				break;
 		}
 
 		if(ret >= 0 || firstRun)
@@ -3523,8 +3528,10 @@ static int MenuSettingsOtherMappings()
 				case 1:
 					sprintf (options.value[2], "Home / Right Stick"); break;
 				case 2:
-					sprintf (options.value[2], "R+L+Start"); break;
+					sprintf (options.value[2], "L+R+Start"); break;
 			}
+
+			sprintf (options.value[3], "%s", GCSettings.MapABXYRightStick == 1 ? "On" : "Off");
 
 			optionBrowser.TriggerUpdate();
 		}

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3403,6 +3403,7 @@ static int MenuSettingsOtherMappings()
 
 	sprintf(options.name[i++], "Enable Turbo Mode");
 	sprintf(options.name[i++], "Turbo Mode Button");
+	sprintf(options.name[i++], "Menu Toggle");
 
 	options.length = i;
 
@@ -3468,6 +3469,12 @@ static int MenuSettingsOtherMappings()
 				if (GCSettings.TurboModeButton > 14)
 					GCSettings.TurboModeButton = 0;
 				break;
+
+			case 2:
+				GCSettings.GamepadMenuToggle++;
+				if (GCSettings.GamepadMenuToggle > 2)
+					GCSettings.GamepadMenuToggle = 0;
+				break;
 		}
 
 		if(ret >= 0 || firstRun)
@@ -3507,6 +3514,16 @@ static int MenuSettingsOtherMappings()
 					sprintf (options.value[1], "Plus"); break;
 				case 14:
 					sprintf (options.value[1], "Minus"); break;
+			}
+
+			switch(GCSettings.GamepadMenuToggle)
+			{
+				case 0:
+					sprintf (options.value[2], "Default (All Enabled)"); break;
+				case 1:
+					sprintf (options.value[2], "Home / Right Stick"); break;
+				case 2:
+					sprintf (options.value[2], "R+L+Start"); break;
 			}
 
 			optionBrowser.TriggerUpdate();

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -160,6 +160,7 @@ preparePrefsData ()
 	createXMLSetting("TurboModeEnabled", "Turbo Mode Enabled", toStr(GCSettings.TurboModeEnabled));
 	createXMLSetting("TurboModeButton", "Turbo Mode Button", toStr(GCSettings.TurboModeButton));
 	createXMLSetting("GamepadMenuToggle", "Gamepad Menu Toggle", toStr(GCSettings.GamepadMenuToggle));
+	createXMLSetting("MapABXYRightStick", "Map ABXY Right Stick", toStr(GCSettings.MapABXYRightStick));
 
 	createXMLSection("Menu", "Menu Settings");
 
@@ -349,6 +350,7 @@ decodePrefsData ()
 			loadXMLSetting(&GCSettings.TurboModeEnabled, "TurboModeEnabled");
 			loadXMLSetting(&GCSettings.TurboModeButton, "TurboModeButton");
 			loadXMLSetting(&GCSettings.GamepadMenuToggle, "GamepadMenuToggle");
+			loadXMLSetting(&GCSettings.MapABXYRightStick, "MapABXYRightStick");
 			
 			// Audio Settings
 			
@@ -548,6 +550,7 @@ DefaultSettings ()
 	GCSettings.TurboModeEnabled = 1; // Enabled by default
 	GCSettings.TurboModeButton = 0; // Default is Right Analog Stick (0)
 	GCSettings.GamepadMenuToggle = 0; // 0 = All options (default), 1 = C-Stick left, 2 = R+L+Start
+	GCSettings.MapABXYRightStick = 0; 
 }
 
 /****************************************************************************

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -159,6 +159,7 @@ preparePrefsData ()
 	createXMLSetting("Interpolation", "Interpolation", toStr(GCSettings.Interpolation));
 	createXMLSetting("TurboModeEnabled", "Turbo Mode Enabled", toStr(GCSettings.TurboModeEnabled));
 	createXMLSetting("TurboModeButton", "Turbo Mode Button", toStr(GCSettings.TurboModeButton));
+	createXMLSetting("GamepadMenuToggle", "Gamepad Menu Toggle", toStr(GCSettings.GamepadMenuToggle));
 
 	createXMLSection("Menu", "Menu Settings");
 
@@ -347,6 +348,7 @@ decodePrefsData ()
 			loadXMLSetting(&GCSettings.yshift, "yshift");
 			loadXMLSetting(&GCSettings.TurboModeEnabled, "TurboModeEnabled");
 			loadXMLSetting(&GCSettings.TurboModeButton, "TurboModeButton");
+			loadXMLSetting(&GCSettings.GamepadMenuToggle, "GamepadMenuToggle");
 			
 			// Audio Settings
 			
@@ -545,6 +547,7 @@ DefaultSettings ()
 
 	GCSettings.TurboModeEnabled = 1; // Enabled by default
 	GCSettings.TurboModeButton = 0; // Default is Right Analog Stick (0)
+	GCSettings.GamepadMenuToggle = 0; // 0 = All options (default), 1 = C-Stick left, 2 = R+L+Start
 }
 
 /****************************************************************************

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -147,6 +147,7 @@ struct SGCSettings{
 	int		TurboModeEnabled; // 0 - disabled, 1 - enabled
 	int		TurboModeButton;
 	int		GamepadMenuToggle;
+	int		MapABXYRightStick;
 };
 
 void ExitApp();

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -146,6 +146,7 @@ struct SGCSettings{
 
 	int		TurboModeEnabled; // 0 - disabled, 1 - enabled
 	int		TurboModeButton;
+	int		GamepadMenuToggle;
 };
 
 void ExitApp();


### PR DESCRIPTION
This adds two new settings to the "Other Mappings" menu: 

- Menu Toggle (options are "Default (All Enabled)", "Home / Right Stick" and "L+R+Start"). 
- Map ABXY to Right Stick (On/Off)

Being able to use the right stick for ABXY allows games like Smash TV to be played like a modern twin stick shooter. The Menu Toggle setting lets the user enable one or both of the currently available menu triggers, and is necessary for the ABXY remapping to work on Gamecube controllers (so the menu isn't always opened on C-stick left).