### PR TITLE
Update GitHub's "Upload Artifact Builds" plugin to v3.1.0 on workflow

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -36,7 +36,7 @@ jobs:
         cp executables/snes9xgx-wii.dol dist/Snes9xGX/apps/snes9xgx/boot.dol
 
     - name: Upload Wii artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       if: ${{ matrix.image == 'Wii' }}
       with: 
         name: Snes9xGX
@@ -55,7 +55,7 @@ jobs:
         cp executables/snes9xgx-gc.dol dist/Snes9xGX-GameCube/
     
     - name: Upload GameCube artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.0
       if: ${{ matrix.image == 'GameCube' }}
       with: 
         name: Snes9xGX-GameCube


### PR DESCRIPTION
Since GitHub will make obsolete (deprecated) the v2 version of the Upload Artifact Builds, which the workflow used, i decided to update the workflow of GitHub to the latest v3.1.0.