### PR TITLE
Various minor updates/improvements

### DIFF
--- a/source/input.cpp
+++ b/source/input.cpp
@@ -772,7 +772,7 @@ bool MenuRequested()
 				return true;
 			}
 		}
-		else if (GCSettings.GamepadMenuToggle == 2) // L+R+Start combo only (frees up the right stick on GC/3rd party gamepad)
+		else if (GCSettings.GamepadMenuToggle == 2) // L+R+Start / 1+2+Plus (Wiimote) combo only (frees up the right stick on GC/3rd party gamepad)
 		{
 			if (
 				(userInput[i].pad.btns_h & PAD_TRIGGER_L &&
@@ -782,6 +782,9 @@ bool MenuRequested()
 				|| (userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_L &&
 				userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_R &&
 				userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_PLUS)
+				|| (userInput[i].wpad->btns_h & WPAD_BUTTON_PLUS &&
+				userInput[i].wpad->btns_h & WPAD_BUTTON_1 &&
+				userInput[i].wpad->btns_h & WPAD_BUTTON_2)
 				#endif
 			)
 			{
@@ -802,6 +805,9 @@ bool MenuRequested()
 				(userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_L &&
 				userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_R &&
 				userInput[i].wpad->btns_h & WPAD_CLASSIC_BUTTON_PLUS)
+				|| (userInput[i].wpad->btns_h & WPAD_BUTTON_PLUS &&
+				userInput[i].wpad->btns_h & WPAD_BUTTON_1 &&
+				userInput[i].wpad->btns_h & WPAD_BUTTON_2)
 				#endif
 			)
 			{

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3852,6 +3852,7 @@ static int MenuSettingsAudio()
 	bool firstRun = true;
 	OptionList options;
 	sprintf(options.name[i++], "Interpolation");
+	sprintf(options.name[i++], "Mute Game Audio");
 	options.length = i;
 	for(i=0; i < options.length; i++)
 		options.value[i][0] = 0;
@@ -3903,7 +3904,7 @@ static int MenuSettingsAudio()
 		
 		switch (ret)
 		{
-		case 0:
+			case 0:
 				GCSettings.Interpolation++;
 				if (GCSettings.Interpolation > 4) {
 					GCSettings.Interpolation = 0;
@@ -3918,6 +3919,10 @@ static int MenuSettingsAudio()
 				}
 				break;
 				S9xReset();
+
+			case 1:
+				GCSettings.MuteAudio ^= 1;
+				break;
 		}
 		
 	if(ret >= 0 || firstRun)
@@ -3937,6 +3942,9 @@ static int MenuSettingsAudio()
 				case 4:
 					sprintf (options.value[0], "None"); break;
 			}
+
+			sprintf (options.value[1], "%s", GCSettings.MuteAudio ? "On" : "Off");
+
 			optionBrowser.TriggerUpdate();
 		}
 		if(backBtn.GetState() == STATE_CLICKED)

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -819,7 +819,7 @@ static void WindowCredits(void * ptr)
 	creditsBoxImg.SetAlignment(ALIGN_CENTRE, ALIGN_MIDDLE);
 	creditsWindowBox.Append(&creditsBoxImg);
 
-	int numEntries = 24;
+	int numEntries = 25;
 	GuiText * txt[numEntries];
 
 	txt[i] = new GuiText("Credits", 30, (GXColor){0, 0, 0, 255});
@@ -836,6 +836,8 @@ static void WindowCredits(void * ptr)
 	txt[i] = new GuiText("Additional improvements");
 	txt[i]->SetPosition(60,y); i++;
 	txt[i] = new GuiText("Zopenko, michniewski");
+	txt[i]->SetPosition(350,y); i++; y+=24;
+	txt[i] = new GuiText("InfiniteBlue, others");
 	txt[i]->SetPosition(350,y); i++; y+=24;
 	txt[i] = new GuiText("Menu artwork");
 	txt[i]->SetPosition(60,y); i++;

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -218,6 +218,11 @@ WindowPrompt(const char *title, const char *msg, const char *btn1Label, const ch
 	GuiImageData btnOutline(button_prompt_png);
 	GuiImageData btnOutlineOver(button_prompt_over_png);
 
+	GuiTrigger trigB;
+	GuiTrigger trig1;
+	trigB.SetButtonOnlyTrigger(-1, WPAD_BUTTON_B | WPAD_CLASSIC_BUTTON_B, PAD_BUTTON_B, WIIDRC_BUTTON_B);
+	trig1.SetButtonOnlyTrigger(-1, WPAD_BUTTON_1, 0, 0);
+
 	GuiImageData dialogBox(dialogue_box_png);
 	GuiImage dialogBoxImg(&dialogBox);
 
@@ -243,6 +248,8 @@ WindowPrompt(const char *title, const char *msg, const char *btn1Label, const ch
 	{
 		btn1.SetAlignment(ALIGN_CENTRE, ALIGN_BOTTOM);
 		btn1.SetPosition(0, -25);
+		btn1.SetTrigger(&trigB);
+		btn1.SetTrigger(&trig1);
 	}
 
 	btn1.SetLabel(&btn1Txt);
@@ -276,7 +283,11 @@ WindowPrompt(const char *title, const char *msg, const char *btn1Label, const ch
 	promptWindow.Append(&btn1);
 
 	if(btn2Label)
+	{
 		promptWindow.Append(&btn2);
+		btn2.SetTrigger(&trigB);
+		btn2.SetTrigger(&trig1);
+	}	
 
 	promptWindow.SetEffect(EFFECT_SLIDE_TOP | EFFECT_SLIDE_IN, 50);
 	CancelAction();

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3574,7 +3574,7 @@ static int MenuSettingsOtherMappings()
 				case 1:
 					sprintf (options.value[2], "Home / Right Stick"); break;
 				case 2:
-					sprintf (options.value[2], "L+R+Start"); break;
+					sprintf (options.value[2], "L+R+Start / 1+2+Plus"); break;
 			}
 
 			sprintf (options.value[3], "%s", GCSettings.MapABXYRightStick == 1 ? "On" : "Off");

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3440,7 +3440,7 @@ static int MenuSettingsOtherMappings()
 	bool firstRun = true;
 	OptionList options;
 
-	sprintf(options.name[i++], "Enable Turbo Mode");
+	sprintf(options.name[i++], "Turbo Mode");
 	sprintf(options.name[i++], "Turbo Mode Button");
 	sprintf(options.name[i++], "Menu Toggle");
 	sprintf(options.name[i++], "Map ABXY to Right Stick");
@@ -3536,7 +3536,7 @@ static int MenuSettingsOtherMappings()
 			switch(GCSettings.TurboModeButton)
 			{
 				case 0:
-					sprintf (options.value[1], "Right Stick (default)"); break;
+					sprintf (options.value[1], "Default (Right Stick)"); break;
 				case 1:
 					sprintf (options.value[1], "A"); break;
 				case 2:
@@ -3610,7 +3610,7 @@ static int MenuSettingsVideo()
 	sprintf(options.name[i++], "Screen Position");
 	sprintf(options.name[i++], "Video Mode");
 	sprintf(options.name[i++], "SNES Hi-Res Mode");
-	sprintf(options.name[i++], "Sprites per-line Limit");
+	sprintf(options.name[i++], "Sprites Per-Line Limit");
 	sprintf(options.name[i++], "Crosshair");
 	sprintf(options.name[i++], "Show Framerate");
 	sprintf(options.name[i++], "Show Local Time");
@@ -3758,7 +3758,7 @@ static int MenuSettingsVideo()
 			firstRun = false;
 
 			if (GCSettings.render == 0)
-				sprintf (options.value[0], "Original");
+				sprintf (options.value[0], "Original (240p)");
 			else if (GCSettings.render == 1)
 				sprintf (options.value[0], "Filtered");
 			else if (GCSettings.render == 2)
@@ -4483,7 +4483,7 @@ static int MenuSettingsMenu()
 			if (GCSettings.ExitAction == 1)
 				sprintf (options.value[0], "Return to Wii Menu");
 			else if (GCSettings.ExitAction == 2)
-				sprintf (options.value[0], "Power off Wii");
+				sprintf (options.value[0], "Power Off Wii");
 			else if (GCSettings.ExitAction == 3)
 				sprintf (options.value[0], "Return to Loader");
 			else

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -157,6 +157,7 @@ preparePrefsData ()
 	createXMLSetting("yshift", "Vertical Video Shift", toStr(GCSettings.yshift));
 	createXMLSetting("sfxOverclock", "SuperFX Overclock", toStr(GCSettings.sfxOverclock));
 	createXMLSetting("Interpolation", "Interpolation", toStr(GCSettings.Interpolation));
+	createXMLSetting("MuteAudio", "Mute", toStr(GCSettings.MuteAudio));
 	createXMLSetting("TurboModeEnabled", "Turbo Mode Enabled", toStr(GCSettings.TurboModeEnabled));
 	createXMLSetting("TurboModeButton", "Turbo Mode Button", toStr(GCSettings.TurboModeButton));
 	createXMLSetting("GamepadMenuToggle", "Gamepad Menu Toggle", toStr(GCSettings.GamepadMenuToggle));
@@ -355,6 +356,7 @@ decodePrefsData ()
 			// Audio Settings
 			
 			loadXMLSetting(&GCSettings.Interpolation, "Interpolation");
+			loadXMLSetting(&GCSettings.MuteAudio, "MuteAudio");
 
 			// Emulation Settings
 
@@ -516,8 +518,7 @@ DefaultSettings ()
 	Settings.SoundInputRate = 31920;
 	Settings.DynamicRateControl = true;
 	Settings.SeparateEchoBuffer = false;
-	
-	// Interpolation Method
+	GCSettings.MuteAudio = 0;
 	GCSettings.Interpolation = 0;
 	Settings.InterpolationMethod = DSP_INTERPOLATION_GAUSSIAN;
 

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -531,6 +531,7 @@ int main(int argc, char *argv[])
 		ScreenshotRequested = 0;
 		SwitchAudioMode(0);
 
+		Settings.Mute = GCSettings.MuteAudio;
 		Settings.SupportHiRes = (GCSettings.HiResolution == 1);
 		Settings.MaxSpriteTilesPerLine = (GCSettings.SpriteLimit ? 34 : 128);
 		Settings.AutoDisplayMessages = (Settings.DisplayFrameRate || Settings.DisplayTime ? true : false);

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -154,6 +154,7 @@ struct SGCSettings{
 	int		sfxOverclock;
 	
 	int		Interpolation;
+	int		MuteAudio;
 
 	int		TurboModeEnabled; // 0 - disabled, 1 - enabled
 	int		TurboModeButton;


### PR DESCRIPTION
- B/1 buttons now trigger the Cancel/No button on 2-button WindowPrompts, and the button on 1-button ones. 
- Added a 1+2+Plus combo to the Menu Toggle options alongside L+R+Start, to eliminate the possibility of a user getting locked out of accessing the menu if they set L+R+Start while using a Wiimote (credit to Niuus of Snes9xRX for the idea).
- An option to mute game audio was added to the Audio Settings menu (adapted from Tanooki16's implementation in Snes9xTX)
- Minor updates to some text strings for consistency/capitalization. The most noteworthy change is renaming the "Original" rendering option to "Original (240p)" - this was done in response to some confusion in CRT gaming forums as to how to enable 240p mode within the GX emulators (even if it's technically 224p here, 240p is the common terminology for what they're looking for). 
- Updated credits.