### PR TITLE
Fix a crash when selecting Cancel after removing an SD/USB device and reopening Snes9xGX

### DIFF
--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -677,6 +677,8 @@ bool LoadPrefs()
 	bool prefFound = false;
 	char filepath[5][MAXPATHLEN];
 	int numDevices;
+	bool sdMounted = false;
+	bool usbMounted = false;
 	
 #ifdef HW_RVL
 	numDevices = 5;
@@ -717,13 +719,15 @@ bool LoadPrefs()
 	// rename snes9x to snes9xgx
 	if(GCSettings.LoadMethod == DEVICE_SD)
 	{
-		if(ChangeInterface(DEVICE_SD, NOTSILENT) && opendir("sd:/snes9x"))
+		sdMounted = ChangeInterface(DEVICE_SD, NOTSILENT);
+		if(sdMounted && opendir("sd:/snes9x"))
 			rename("sd:/snes9x", "sd:/snes9xgx");
 	}
 	else if(GCSettings.LoadMethod == DEVICE_USB)
 	{
-		if(ChangeInterface(DEVICE_USB, NOTSILENT) && opendir("usb:/snes9x"))
-			rename("usb:/snes9x", "usb:/snes9xgx");
+		usbMounted = ChangeInterface(DEVICE_USB, NOTSILENT);
+		if(usbMounted && opendir("usb:/snes9x"))
+			rename("usb:/snes9x", "usb:/snes9xgx");	
 	}
 	else if(GCSettings.LoadMethod == DEVICE_SMB)
 	{
@@ -751,7 +755,7 @@ bool LoadPrefs()
 		sprintf(GCSettings.ArtworkFolder, "snes9xgx/artwork");
 	
 	// attempt to create directories if they don't exist
-	if(GCSettings.LoadMethod == DEVICE_SD || GCSettings.LoadMethod == DEVICE_USB) {
+	if((GCSettings.LoadMethod == DEVICE_SD && sdMounted) || (GCSettings.LoadMethod == DEVICE_USB && usbMounted) ) {
 		char dirPath[MAXPATHLEN];
 		sprintf(dirPath, "%s%s", pathPrefix[GCSettings.LoadMethod], GCSettings.ScreenshotsFolder);
 		CreateDirectory(dirPath);
@@ -774,6 +778,5 @@ bool LoadPrefs()
 	bg_music_size = bg_music_ogg_size;
 	LoadBgMusic();
 #endif
-
 	return prefFound;
 }


### PR DESCRIPTION
If you loaded a game from SD/USB, closed Snes9xGX, then removed the device before re-launching the app, an ErrorPromptRetry dialog would appear ("Device not found") asking to Retry or Cancel. If Cancel was selected with the device still removed, the app would crash.

In preferences.cpp, it was trying to create directories on the devices without first checking if they were mounted or not - this commit fixes the problem.