### PR TITLE
Fix default game selection menu "jump" upon startup w/classic controller

### DIFF
--- a/source/gui/gui_trigger.cpp
+++ b/source/gui/gui_trigger.cpp
@@ -133,6 +133,10 @@ s8 GuiTrigger::WPAD_Stick(u8 stick, int axis)
 			center = js->center.x;
 		}
 
+		if(min == max) {
+			return 0;
+		}
+
 		// some 3rd party controllers return invalid analog sticks calibration data
 		if ((min >= center) || (max <= center)) {
 			// force default calibration settings

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -427,6 +427,7 @@ int main(int argc, char *argv[])
 	WiiDRC_Init();
 	isWiiVC = WiiDRC_Inited();
 	WPAD_Init();
+	//usleep(2000000);
 	WPAD_SetPowerButtonCallback((WPADShutdownCallback)ShutdownCB);
 	DI_Init();
 	USBStorage_Initialize();

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -427,7 +427,6 @@ int main(int argc, char *argv[])
 	WiiDRC_Init();
 	isWiiVC = WiiDRC_Inited();
 	WPAD_Init();
-	//usleep(2000000);
 	WPAD_SetPowerButtonCallback((WPADShutdownCallback)ShutdownCB);
 	DI_Init();
 	USBStorage_Initialize();


### PR DESCRIPTION
(Marking as a draft for now until clarification)

When booting Snes9xGX with a classic controller, the game browser would highlight the previous game played like normal, then "jump" 40-60 games up the list as soon as the classic controller initialized (blue light for port 1 on the wiimote turns on). This did not happen with the GCN controller or solo wiimote. This was a regression introduced in commit https://github.com/dborth/snes9xgx/commit/05b4abce9812760e57bc86de33b8896b70216617

Reverting the commit eliminates the "jump", but I'm not aware of the controller issue the commit was originally trying to solve. I also don't have a 3rd party controller to test with if those were affected. 

@dborth could you elaborate on the reasoning behind removing the if statement to fix controllers with bad calibration data?

Alternatively, adding a usleep for 2 seconds after WPAD_Init in the place indicated below seems to give the controller enough time to initialize before the menu appears, but it's not exactly an elegant solution. However, if you think this is preferable to reverting the commit, please let me know and I'll update accordingly.

This would fix issue https://github.com/dborth/snes9xgx/issues/936.

 