### PR TITLE
Add a B/1 button press to cancel the button remapping prompt

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -2979,8 +2979,7 @@ ButtonMappingWindow()
 							pressed = 0; // not a valid input (Nunchuk Z/C is assigned as Classic Controller Up/Left for some reason)
 						else if(pressed <= 0x1000)
 							pressed = 0;
-						if((userInput[0].wpad->exp.classic.type == 2 && (userInput[0].wpad->btns_d & WPAD_CLASSIC_BUTTON_B)) ||
-								userInput[0].pad.btns_d & PAD_BUTTON_B || 
+						if(userInput[0].pad.btns_d & PAD_BUTTON_B || 
 								userInput[0].wiidrcdata.btns_d & WIIDRC_BUTTON_B ||
 								userInput[0].wpad->btns_d & WPAD_BUTTON_B ||
 								userInput[0].wpad->btns_d & WPAD_BUTTON_1)
@@ -2992,8 +2991,7 @@ ButtonMappingWindow()
 							pressed = 0; // not a valid input
 						else if(pressed <= 0x1000)
 							pressed = 0;
-						if((userInput[0].wpad->exp.classic.type < 2 && (userInput[0].wpad->btns_d & WPAD_CLASSIC_BUTTON_B)) ||
-								userInput[0].pad.btns_d & PAD_BUTTON_B || 
+						if(userInput[0].pad.btns_d & PAD_BUTTON_B || 
 								userInput[0].wiidrcdata.btns_d & WIIDRC_BUTTON_B ||
 								userInput[0].wpad->btns_d & WPAD_BUTTON_B ||
 								userInput[0].wpad->btns_d & WPAD_BUTTON_1)
@@ -3004,8 +3002,8 @@ ButtonMappingWindow()
 						if(userInput[0].wpad->exp.type != WPAD_EXP_NUNCHUK)
 							pressed = 0; // not a valid input
 						if((userInput[0].wpad->exp.type != WPAD_EXP_NUNCHUK && userInput[0].wpad->btns_d & WPAD_BUTTON_B) ||
+								(userInput[0].wpad->exp.type != WPAD_EXP_NUNCHUK && userInput[0].wpad->btns_d & WPAD_BUTTON_1) ||
 								userInput[0].pad.btns_d & PAD_BUTTON_B || 
-								userInput[0].wpad->btns_d & WPAD_BUTTON_1 ||
 								userInput[0].wiidrcdata.btns_d & WIIDRC_BUTTON_B ||
 								userInput[0].wpad->btns_d & WPAD_CLASSIC_BUTTON_B)
 							buttonMappingCancelled = true;

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -95,6 +95,7 @@ static char progressTitle[101];
 static char progressMsg[201];
 static int progressDone = 0;
 static int progressTotal = 0;
+static bool buttonMappingCancelled = false;
 
 u8 * bg_music;
 u32 bg_music_size;
@@ -2918,8 +2919,9 @@ ButtonMappingWindow()
 	ResumeGui();
 
 	u32 pressed = 0;
-
-	while(pressed == 0)
+	
+	buttonMappingCancelled = false;
+	while(pressed == 0 && !buttonMappingCancelled)
 	{
 		usleep(THREAD_SLEEP);
 
@@ -2935,10 +2937,22 @@ ButtonMappingWindow()
 
 			if(userInput[0].wpad->btns_d == WPAD_BUTTON_HOME)
 				pressed = WPAD_BUTTON_HOME;
+
+			if(userInput[0].wpad->btns_d & WPAD_CLASSIC_BUTTON_B ||
+					userInput[0].wpad->btns_d & WPAD_BUTTON_B ||
+					userInput[0].wpad->btns_d & WPAD_BUTTON_1 ||
+					userInput[0].wiidrcdata.btns_d & WIIDRC_BUTTON_B)
+				buttonMappingCancelled = true; 
 		}
 		else if(mapMenuCtrl == CTRLR_WIIDRC)
 		{
 			pressed = userInput[0].wiidrcdata.btns_d;
+
+			if(userInput[0].wpad->btns_d & WPAD_CLASSIC_BUTTON_B ||
+					userInput[0].wpad->btns_d & WPAD_BUTTON_B ||
+					userInput[0].wpad->btns_d & WPAD_BUTTON_1 ||
+					userInput[0].pad.btns_d & PAD_BUTTON_B)
+				buttonMappingCancelled = true; 
 		}
 		else
 		{
@@ -2952,24 +2966,49 @@ ButtonMappingWindow()
 					case CTRLR_WIIMOTE:
 						if(pressed > 0x1000)
 							pressed = 0; // not a valid input
+						if(userInput[0].pad.btns_d & PAD_BUTTON_B || 
+								userInput[0].wiidrcdata.btns_d & WIIDRC_BUTTON_B ||
+								userInput[0].wpad->btns_d & WPAD_CLASSIC_BUTTON_B)
+							buttonMappingCancelled = true;
 						break;
 
 					case CTRLR_CLASSIC:
 						if(userInput[0].wpad->exp.type != WPAD_EXP_CLASSIC && userInput[0].wpad->exp.classic.type < 2)
 							pressed = 0; // not a valid input
+						else if(userInput[0].wpad->exp.type == WPAD_EXP_NUNCHUK)
+							pressed = 0; // not a valid input (Nunchuk Z/C is assigned as Classic Controller Up/Left for some reason)
 						else if(pressed <= 0x1000)
 							pressed = 0;
+						if((userInput[0].wpad->exp.classic.type == 2 && (userInput[0].wpad->btns_d & WPAD_CLASSIC_BUTTON_B)) ||
+								userInput[0].pad.btns_d & PAD_BUTTON_B || 
+								userInput[0].wiidrcdata.btns_d & WIIDRC_BUTTON_B ||
+								userInput[0].wpad->btns_d & WPAD_BUTTON_B ||
+								userInput[0].wpad->btns_d & WPAD_BUTTON_1)
+							buttonMappingCancelled = true;
 						break;
+
 					case CTRLR_WUPC:
 						if(userInput[0].wpad->exp.type != WPAD_EXP_CLASSIC && userInput[0].wpad->exp.classic.type == 2)
 							pressed = 0; // not a valid input
 						else if(pressed <= 0x1000)
 							pressed = 0;
+						if((userInput[0].wpad->exp.classic.type < 2 && (userInput[0].wpad->btns_d & WPAD_CLASSIC_BUTTON_B)) ||
+								userInput[0].pad.btns_d & PAD_BUTTON_B || 
+								userInput[0].wiidrcdata.btns_d & WIIDRC_BUTTON_B ||
+								userInput[0].wpad->btns_d & WPAD_BUTTON_B ||
+								userInput[0].wpad->btns_d & WPAD_BUTTON_1)
+							buttonMappingCancelled = true;
 						break;
 
 					case CTRLR_NUNCHUK:
 						if(userInput[0].wpad->exp.type != WPAD_EXP_NUNCHUK)
 							pressed = 0; // not a valid input
+						if((userInput[0].wpad->exp.type != WPAD_EXP_NUNCHUK && userInput[0].wpad->btns_d & WPAD_BUTTON_B) ||
+								userInput[0].pad.btns_d & PAD_BUTTON_B || 
+								userInput[0].wpad->btns_d & WPAD_BUTTON_1 ||
+								userInput[0].wiidrcdata.btns_d & WIIDRC_BUTTON_B ||
+								userInput[0].wpad->btns_d & WPAD_CLASSIC_BUTTON_B)
+							buttonMappingCancelled = true;
 						break;
 				}
 			}
@@ -3138,8 +3177,13 @@ static int MenuSettingsMappingsMap()
 
 		if(ret >= 0)
 		{
-			// get a button selection from user
-			btnmap[mapMenuCtrlSNES][mapMenuCtrl][ret] = ButtonMappingWindow();
+			int buttonPressed = ButtonMappingWindow();
+			
+			if (!buttonMappingCancelled)
+			{
+				// get a button selection from user if the remap wasn't cancelled
+				btnmap[mapMenuCtrlSNES][mapMenuCtrl][ret] = buttonPressed;
+			}
 		}
 
 		if(ret >= 0 || firstRun)


### PR DESCRIPTION
Previously, if the user accessed the button remapping prompt for a controller type other than the one they were currently using, they would have to connect the controller of said type in order to input a remapping to close the prompt. If they did not have the required controller, they would have to press the home button on a Wiimote to close the prompt, but it would clear the selected mapping, and the user would have to remap it afterwards. Either way, the user was forced to modify the mappings if they wanted to close the prompt in-app. The only workaround without changing any mappings was rebooting the Wii.

These changes make it so the user can press the B or 1 buttons to cancel the button remapping prompt when accessed for a controller type other than the one they're currently using. No changes are made to the mappings when triggered, and it can be done with any controller type.

Additionally, pressing the Z or C Nunchuck buttons on the Classic Controller remapping would map them to Up/Left for some reason - this (probably unintended) behavior is now prevented.