### PR TITLE
Snes9x - msu1: revert to start for invalid loop positions

### DIFF
--- a/source/snes9x/msu1.cpp
+++ b/source/snes9x/msu1.cpp
@@ -262,7 +262,14 @@ void S9xMSU1Generate(size_t sample_count)
 			{
 				if (MSU1.MSU1_STATUS & AudioRepeating)
 				{
-					MSU1.MSU1_AUDIO_POS = audioLoopPos;
+					if (audioLoopPos < MSU1.MSU1_AUDIO_POS)
+					{
+						MSU1.MSU1_AUDIO_POS = audioLoopPos;
+					}
+					else // if the loop point is invalid, revert to start
+					{
+						MSU1.MSU1_AUDIO_POS = 8;
+					}
 					REVERT_STREAM(audioStream, MSU1.MSU1_AUDIO_POS, 0);
 				}
 				else


### PR DESCRIPTION
@dborth I've backported this commit from Snes9x.

I'm not sure if the following also needs to be added in some way because Snes9x GX's apu is different from Snes9x:
https://github.com/snes9xgit/snes9x/commit/3c4982edddfdba482204ed48cf0b1d41ccae5493