### PR TITLE
Add Pre-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build Snes9x GX
+    name: Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -61,3 +61,41 @@ jobs:
         name: Snes9xGX-GameCube
         path: |
          dist/Snes9xGX-GameCube/
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+    - uses: actions/checkout@v3
+      name: Download Artifacts
+        
+    - uses: actions/download-artifact@v3
+      with:
+        path: dist
+
+    - name: Re-zip artifacts
+      run: |
+        cd dist
+        rm -r Snes9xGX/snes9xgx/cheats/*
+        rm -r Snes9xGX/snes9xgx/roms/*
+        rm -r Snes9xGX/snes9xgx/saves/*
+        zip -r Snes9xGX.zip Snes9xGX
+        zip -r Snes9xGX-GameCube.zip Snes9xGX-GameCube
+
+    - name: Update Git Tag
+      run: |
+        git tag -f Pre-release
+        git push -f origin Pre-release
+    
+    - name: Create Release
+      uses: ncipollo/release-action@v1
+      with:
+        prerelease: true
+        allowUpdates: true
+        removeArtifacts: true
+        replacesArtifacts: false
+        tag: Pre-release
+        artifacts: "dist/*.zip"


### PR DESCRIPTION
Hi @dborth because the Nightly builds will expire over time I've added a Pre-release under the Releases section:
![image](https://user-images.githubusercontent.com/24655170/205273133-a6cee240-6fce-40c1-8f07-9fc6d2a02a0a.png)

The Pre-release looks like the following, everytime an update to the master branch is triggered it will overwrite the previous Pre-Release. I also removed the cheatsdir, romsdir and savesdir dummy files from the zip file:
![image](https://user-images.githubusercontent.com/24655170/205273408-e492ed93-9221-4d99-bff2-e3c23273b645.png)

