### PR TITLE
(Re)added Frameskip option and added PAL 576p support (Tanooki16)

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3666,6 +3666,7 @@ static int MenuSettingsVideo()
 	sprintf(options.name[i++], "Video Mode");
 	sprintf(options.name[i++], "SNES Hi-Res Mode");
 	sprintf(options.name[i++], "Sprites Per-Line Limit");
+	sprintf(options.name[i++], "Frame Skipping");
 	sprintf(options.name[i++], "Crosshair");
 	sprintf(options.name[i++], "Show Framerate");
 	sprintf(options.name[i++], "Show Local Time");
@@ -3770,18 +3771,22 @@ static int MenuSettingsVideo()
 				break;
 
 			case 8:
+				GCSettings.FrameSkip ^= 1;
+				break;
+
+			case 9:
 				GCSettings.crosshair ^= 1;
 				break;
 				
-			case 9:
+			case 10:
 				Settings.DisplayFrameRate ^= 1;
 				break;
 				
-			case 10:
+			case 11:
 				Settings.DisplayTime ^= 1;
 				break;
 				
-			case 11:
+			case 12:
 				#ifdef HW_RVL
 				GCSettings.sfxOverclock++;
 				if (GCSettings.sfxOverclock > 6) {
@@ -3842,15 +3847,18 @@ static int MenuSettingsVideo()
 				case 2:
 					sprintf (options.value[5], "Progressive (480p)"); break;
 				case 3:
-					sprintf (options.value[5], "PAL (50Hz)"); break;
+					sprintf (options.value[5], "Progressive (576p)"); break;
 				case 4:
+					sprintf (options.value[5], "PAL (50Hz)"); break;
+				case 5:
 					sprintf (options.value[5], "PAL (60Hz)"); break;
 			}
 			sprintf (options.value[6], "%s", GCSettings.HiResolution == 1 ? "On" : "Off");
 			sprintf (options.value[7], "%s", GCSettings.SpriteLimit == 1 ? "On" : "Off");
-			sprintf (options.value[8], "%s", GCSettings.crosshair == 1 ? "On" : "Off");
-			sprintf (options.value[9], "%s", Settings.DisplayFrameRate ? "On" : "Off");
-			sprintf (options.value[10], "%s", Settings.DisplayTime ? "On" : "Off");
+			sprintf (options.value[8], "%s", GCSettings.FrameSkip == 1 ? "On" : "Off");
+			sprintf (options.value[9], "%s", GCSettings.crosshair == 1 ? "On" : "Off");
+			sprintf (options.value[10], "%s", Settings.DisplayFrameRate ? "On" : "Off");
+			sprintf (options.value[11], "%s", Settings.DisplayTime ? "On" : "Off");
 			switch(GCSettings.sfxOverclock)
 			{
 				case 0:

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3758,7 +3758,7 @@ static int MenuSettingsVideo()
 
 			case 5:
 				GCSettings.videomode++;
-				if(GCSettings.videomode > 4)
+				if(GCSettings.videomode > 5)
 					GCSettings.videomode = 0;
 				break;
 				

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -153,6 +153,7 @@ preparePrefsData ()
 	createXMLSetting("FilterMethod", "Filter Method", toStr(GCSettings.FilterMethod));
 	createXMLSetting("HiResolution", "SNES Hi-Res Mode", toStr(GCSettings.HiResolution));
 	createXMLSetting("SpriteLimit", "Sprites per-line Limit", toStr(GCSettings.SpriteLimit));
+	createXMLSetting("FrameSkip", "Frame Skipping", toStr(GCSettings.FrameSkip));
 	createXMLSetting("xshift", "Horizontal Video Shift", toStr(GCSettings.xshift));
 	createXMLSetting("yshift", "Vertical Video Shift", toStr(GCSettings.yshift));
 	createXMLSetting("sfxOverclock", "SuperFX Overclock", toStr(GCSettings.sfxOverclock));
@@ -346,6 +347,7 @@ decodePrefsData ()
 			loadXMLSetting(&GCSettings.FilterMethod, "FilterMethod");
 			loadXMLSetting(&GCSettings.HiResolution, "HiResolution");
 			loadXMLSetting(&GCSettings.SpriteLimit, "SpriteLimit");
+			loadXMLSetting(&GCSettings.FrameSkip, "FrameSkip");
 			loadXMLSetting(&GCSettings.xshift, "xshift");
 			loadXMLSetting(&GCSettings.yshift, "yshift");
 			loadXMLSetting(&GCSettings.TurboModeEnabled, "TurboModeEnabled");
@@ -426,7 +428,7 @@ void FixInvalidSettings()
 		GCSettings.Controller = CTRL_PAD2;
 	if(!(GCSettings.render >= 0 && GCSettings.render < 5))
 		GCSettings.render = 3;
-	if(!(GCSettings.videomode >= 0 && GCSettings.videomode < 5))
+	if(!(GCSettings.videomode >= 0 && GCSettings.videomode < 6))
 		GCSettings.videomode = 0;
 }
 
@@ -533,13 +535,14 @@ DefaultSettings ()
 	Settings.DisplayTime = false;
 	GCSettings.HiResolution = 1; // Enabled by default
 	GCSettings.SpriteLimit = 1; // Enabled by default
+	GCSettings.FrameSkip = 1; // Enabled by default
 
 	// Frame timings in 50hz and 60hz cpu mode
 	Settings.FrameTimePAL = 20000;
 	Settings.FrameTimeNTSC = 16667;
 
 	GCSettings.sfxOverclock = 0;
-	/* Initialize SuperFX CPU to normal speed by default */
+	/* Initialize Super FX CPU to normal speed by default */
 	Settings.SuperFXSpeedPerLine = 5823405;
 	
 	Settings.SuperFXClockMultiplier = 100;

--- a/source/snes9xgx.cpp
+++ b/source/snes9xgx.cpp
@@ -534,6 +534,7 @@ int main(int argc, char *argv[])
 		Settings.Mute = GCSettings.MuteAudio;
 		Settings.SupportHiRes = (GCSettings.HiResolution == 1);
 		Settings.MaxSpriteTilesPerLine = (GCSettings.SpriteLimit ? 34 : 128);
+		Settings.SkipFrames = (GCSettings.FrameSkip ? AUTO_FRAMERATE : 0);
 		Settings.AutoDisplayMessages = (Settings.DisplayFrameRate || Settings.DisplayTime ? true : false);
 		Settings.MultiPlayer5Master = (GCSettings.Controller == CTRL_PAD4 ? true : false);
 		Settings.SuperScopeMaster = (GCSettings.Controller == CTRL_SCOPE ? true : false);

--- a/source/snes9xgx.h
+++ b/source/snes9xgx.h
@@ -133,12 +133,13 @@ struct SGCSettings{
 
 	float	zoomHor; // horizontal zoom amount
 	float	zoomVert; // vertical zoom amount
-	int		videomode; // 0 - automatic, 1 - NTSC (480i), 2 - Progressive (480p), 3 - PAL (50Hz), 4 - PAL (60Hz)
+	int		videomode; // 0 - automatic, 1 - NTSC (480i), 2 - Progressive (480p), 3 - Progressive (576p), 4 - PAL (50Hz), 5 - PAL (60Hz)
 	int		render;		// 0 - original, 1 - filtered, 2 - unfiltered
 	int		FilterMethod; // convert to RenderFilter
 	int		Controller;
 	int		HiResolution;
 	int		SpriteLimit;
+	int		FrameSkip;
 	int		crosshair;
 	int		widescreen;	// 0 - 4:3 aspect, 1 - 16:9 aspect
 	int		xshift;	// video output shift

--- a/source/video.cpp
+++ b/source/video.cpp
@@ -108,9 +108,7 @@ static camera cam = {
 };
 
 
-/***
-*** Custom Video modes (used to emulate original console video modes)
-***/
+/*** Custom Video modes (used to emulate original console video modes) ***/
 
 /** Original SNES PAL Resolutions: **/
 
@@ -261,8 +259,8 @@ static GXRModeObj TV_Custom;
 
 /* TV Modes table */
 static GXRModeObj *tvmodes[4] = {
-	&TV_239p, &TV_478i,			/* Snes PAL video modes */
-	&TV_224p, &TV_448i,			/* Snes NTSC video modes */
+	&TV_239p, &TV_478i,			/* SNES PAL video modes */
+	&TV_224p, &TV_448i,			/* SNES NTSC video modes */
 };
 
 /****************************************************************************
@@ -401,10 +399,13 @@ static GXRModeObj * FindVideoMode()
 		case 2: // Progressive (480p)
 			mode = &TVNtsc480Prog;
 			break;
-		case 3: // PAL (50Hz)
+		case 3: // Progressive (576p)
+			mode = &TVPal576ProgScale;
+			break;
+		case 4: // PAL (50Hz)
 			mode = &TVPal576IntDfScale;
 			break;
-		case 4: // PAL (60Hz)
+		case 5: // PAL (60Hz)
 			mode = &TVEurgb60Hz480IntDf;
 			break;
 		default:
@@ -416,6 +417,8 @@ static GXRModeObj * FindVideoMode()
 			 * on the Wii, the user can do this themselves on their Wii Settings */
 			if(VIDEO_HaveComponentCable())
 				mode = &TVNtsc480Prog;
+			else
+				mode = &TVPal576ProgScale;
 			#endif
 
 			break;
@@ -430,9 +433,13 @@ static GXRModeObj * FindVideoMode()
 
 			// Original Video modes (forced to PAL 50Hz)
 			// set video signal mode
+			TV_239p.viTVMode = VI_TVMODE_PAL_DS;
+			TV_478i.viTVMode = VI_TVMODE_PAL_INT;
 			TV_224p.viTVMode = VI_TVMODE_PAL_DS;
 			TV_448i.viTVMode = VI_TVMODE_PAL_INT;
 			// set VI position
+			TV_239p.viYOrigin = (VI_MAX_HEIGHT_PAL/2 - 478/2)/2;
+			TV_478i.viYOrigin = (VI_MAX_HEIGHT_PAL - 478)/2;
 			TV_224p.viYOrigin = (VI_MAX_HEIGHT_PAL/2 - 448/2)/2;
 			TV_448i.viYOrigin = (VI_MAX_HEIGHT_PAL - 448)/2;
 			break;
@@ -473,7 +480,7 @@ static GXRModeObj * FindVideoMode()
 	}
 
 	// check for progressive scan
-	if (mode->viTVMode == VI_TVMODE_NTSC_PROG)
+	if (mode->viTVMode == VI_TVMODE_NTSC_PROG || VI_TVMODE_PAL_PROG)
 		progressive = true;
 	else
 		progressive = false;
@@ -538,7 +545,6 @@ static void SetupVideoMode(GXRModeObj * mode)
  * This function MUST be called at startup.
  * - also sets up menu video mode
  ***************************************************************************/
-
 void
 InitGCVideo ()
 {
@@ -635,7 +641,11 @@ ResetVideo_Emu ()
 			rmode->xfbMode = VI_XFBMODE_DF;
 			rmode->viTVMode |= VI_INTERLACE;
 		}
-		Settings.SoundInputRate = 31894;
+
+		if (Settings.PAL == 1)
+			Settings.SoundInputRate = 32090;
+		else
+			Settings.SoundInputRate = 31894;
 		UpdatePlaybackRate();
 	}
 	else


### PR DESCRIPTION
This PR re-implements the Frameskip option and adds support for the video mode Progressive PAL (576p).

The reason why we are reimplementing frameskipping in Snes9x GX is even when this port to GameCube/Wii of Snes9x is optimized pretty well and for use the GC/Wii hardware (and the GX hardware on them), some SNES games (Super FX and SA-1 games are the most common examples) still has some struggles and frame drops. (Examples: Yoshi's Island, Kirby's Dream Land 3).

About PAL 576p, the reason for add that is because there are some SNES games that are PAL-optimized (Donkey Kong Country is the most common example). If such games are ran at 480p (60Hz), the game runs too fast and sound is distorted, but hear by yourself:
https://gbatemp.net/data/video/346/346930-37419543f879951734d09a745cf223a2.mp4

Here's a comparison in a GIF between the current 576i setting (PAL (50 Hz)) and the new PAL 576p mode:
https://gbatemp.net/attachments/9dm9jhy5-gif.347539/

This was taken from Snes9x TX by @Tanooki16, so big thanks to him.