### PR TITLE
Fix Super FX overclock buttons being broken since addition of Frameskip option

### DIFF
--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -3862,19 +3862,19 @@ static int MenuSettingsVideo()
 			switch(GCSettings.sfxOverclock)
 			{
 				case 0:
-					sprintf (options.value[11], "Default"); break;
+					sprintf (options.value[12], "Default"); break;
 				case 1:
-					sprintf (options.value[11], "20 MHz"); break;
+					sprintf (options.value[12], "20 MHz"); break;
 				case 2:
-					sprintf (options.value[11], "40 MHz"); break;
+					sprintf (options.value[12], "40 MHz"); break;
 				case 3:
-					sprintf (options.value[11], "60 MHz"); break;
+					sprintf (options.value[12], "60 MHz"); break;
 				case 4:
-					sprintf (options.value[11], "80 MHz"); break;
+					sprintf (options.value[12], "80 MHz"); break;
 				case 5:
-					sprintf (options.value[11], "100 MHz"); break;
+					sprintf (options.value[12], "100 MHz"); break;
 				case 6:
-					sprintf (options.value[11], "120 MHz"); break;
+					sprintf (options.value[12], "120 MHz"); break;
 			}
 			optionBrowser.TriggerUpdate();
 		}


### PR DESCRIPTION
When making the PR https://github.com/dborth/snes9xgx/pull/1045, i completely forgot to update the order for the Super FX overclocking values buttons, making them corrupt with other settings, caused when i was adding the Frameskip option.

This quick PR fixes that.