### PR TITLE
Snes9x - Fix dvision routine on SA-1 returns the wrong reminder (and …

### DIFF
--- a/source/snes9x/sa1.cpp
+++ b/source/snes9x/sa1.cpp
@@ -563,8 +563,9 @@ void S9xSetSA1 (uint8 byte, uint32 address)
 					{
 						int16 dividend = (int16) SA1.op1;
 						uint16 divisor = (uint16) SA1.op2;
-						uint16	remainder = (dividend >= 0) ? dividend % divisor : (dividend % divisor) + divisor;
-						uint16	quotient  = (dividend - remainder) / divisor;
+						uint32 dividend_ext = dividend + (uint32)divisor * 65536;
+						uint16 remainder = dividend_ext % divisor;
+						uint16 quotient = dividend_ext / divisor;
 						SA1.sum = (remainder << 16) | quotient;
 					}
 


### PR DESCRIPTION
…quotient) on negative dividends

Hi @dborth,

I have backported this change from Snes9x