### PR TITLE
Snes9x - Silence NULL pointer subtraction warning.

### DIFF
--- a/source/snes9x/snapshot.cpp
+++ b/source/snes9x/snapshot.cpp
@@ -48,7 +48,7 @@ enum
 };
 
 #define COUNT(ARRAY)				(sizeof(ARRAY) / sizeof(ARRAY[0]))
-#define Offset(field, structure)	((int) (((char *) (&(((structure) NULL)->field))) - ((char *) NULL)))
+#define Offset(field, structure)	((int) (((char *) (&(((structure) 1)->field))) - ((char *) 1)))
 #define OFFSET(f)					Offset(f, STRUCT *)
 #define DUMMY(f)					Offset(f, struct Obsolete *)
 #define DELETED(f)					(-1)


### PR DESCRIPTION
Use a pointer to address 1 instead.