### PR TITLE
Snes9x - memmap.cpp: some more SRAM value fixes hacks and ExtHiROM fixes. (bearoso)

### DIFF
--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -1132,7 +1132,7 @@ int CMemory::ScoreHiROM (bool8 skip_header, int32 romoff)
 	// Check for extended HiROM expansion used in Mother 2 Deluxe et al.
 	// Looks for size byte 13 (8MB) and an actual ROM size greater than 4MB
 	if (buf[0xd7] == 13 && CalculatedSize > 1024 * 1024 * 4)
-		score += 5;
+		score += 3;
 
 	if (buf[0xd5] & 0x1)
 		score += 2;

--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -3778,6 +3778,7 @@ void CMemory::ApplyROMFixes (void)
 
 	// SRAM value fixes
 	if (match_na("SUPER DRIFT OUT")      || // Super Drift Out
+		match_na("S.F.S.95 della SerieA") ||
 		match_na("SATAN IS OUR FATHER!") ||
 		match_na("goemon 4"))               // Ganbare Goemon Kirakira Douchuu
 		SNESGameFixes.SRAMInitialValue = 0x00;

--- a/source/snes9x/memmap.cpp
+++ b/source/snes9x/memmap.cpp
@@ -3676,6 +3676,7 @@ void CMemory::ApplyROMFixes (void)
 
 	if (!Settings.DisableGameSpecificHacks)
 	{
+		// APU timing hacks
 		if (match_id("AVCJ"))                                      // Rendering Ranger R2
 			Timings.APUSpeedup = 4;
 		if (match_na("CIRCUIT USA"))
@@ -3779,6 +3780,7 @@ void CMemory::ApplyROMFixes (void)
 	// SRAM value fixes
 	if (match_na("SUPER DRIFT OUT")      || // Super Drift Out
 		match_na("S.F.S.95 della SerieA") ||
+		match_id("AACJ") || // Nichibutsu Arcade Classics
 		match_na("SATAN IS OUR FATHER!") ||
 		match_na("goemon 4"))               // Ganbare Goemon Kirakira Douchuu
 		SNESGameFixes.SRAMInitialValue = 0x00;


### PR DESCRIPTION
The SRAM fixes i have commited in my fork but haven't pushed to master until now, so i thought it's good time to add those fixes to Snes9x GX too.
- https://github.com/snes9xgit/snes9x/commit/7943dfa126ef78b7a4f9161e9542c58168a53b4f
- https://github.com/snes9xgit/snes9x/commit/c325cbc2f6d1b4f54f503754a8b8ecdd78d9ad5d

Also added the ExtHiROM fixes from upstream, it fixes Italian translation of SD3.
https://github.com/snes9xgit/snes9x/commit/84ac9475675423be3b3577dfc39db7c44eb7f5a0