### PR TITLE
Add GC Loader to `filebrowser.cpp`

### DIFF
--- a/Makefile.gc
+++ b/Makefile.gc
@@ -10,6 +10,8 @@ endif
 include $(DEVKITPPC)/gamecube_rules
 export	LIBOGC_INC	:=	$(DEVKITPRO)/libogc2/include
 export	LIBOGC_LIB	:=	$(DEVKITPRO)/libogc2/lib/cube
+export	FREETYPE_CFLAGS 	:=	`$(DEVKITPRO)/portlibs/ppc/bin/powerpc-eabi-pkg-config --cflags freetype2`
+export	FREETYPE_LIBS	:=	`$(DEVKITPRO)/portlibs/ppc/bin/powerpc-eabi-pkg-config --libs freetype2`
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
@@ -29,7 +31,7 @@ INCLUDES	:=	source source/snes9x
 # options for code generation
 #---------------------------------------------------------------------------------
 
-CFLAGS	= -g -O3 -Wall $(MACHDEP) $(INCLUDE) `freetype-config --cflags` \
+CFLAGS	= -g -O3 -Wall $(MACHDEP) $(INCLUDE) $(FREETYPE_CFLAGS) \
 				-DHAVE_STDINT_H -DBLARGG_NONPORTABLE -DBLARGG_BIG_ENDIAN -DBLARGG_CPU_POWERPC \
 				-DZLIB -DRIGHTSHIFT_IS_SAR -DCPU_SHUTDOWN -DCORRECT_VRAM_READS \
 				-D_SZ_ONE_DIRECTORY -D_LZMA_IN_CB -D_LZMA_OUT_READ -DNO_SOUND -DUSE_VM \
@@ -46,7 +48,7 @@ LDFLAGS +=	-L../buildtools
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	-lpng -lmxml -ltinysmb -lbba -lfat -liso9660 -lz -logc `freetype-config --libs`
+LIBS	:=	-lpng -lmxml -ltinysmb -lbba -lfat -liso9660 -lz -logc $(FREETYPE_LIBS)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -10,6 +10,8 @@ endif
 include $(DEVKITPPC)/wii_rules
 export	LIBOGC_INC	:=	$(DEVKITPRO)/libogc2/include
 export	LIBOGC_LIB	:=	$(DEVKITPRO)/libogc2/lib/wii
+export	FREETYPE_CFLAGS 	:=	`$(DEVKITPRO)/portlibs/ppc/bin/powerpc-eabi-pkg-config --cflags freetype2`
+export	FREETYPE_LIBS	:=	`$(DEVKITPRO)/portlibs/ppc/bin/powerpc-eabi-pkg-config --libs freetype2`
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
@@ -29,7 +31,7 @@ INCLUDES	:=	source source/snes9x
 # options for code generation
 #---------------------------------------------------------------------------------
 
-CFLAGS	= -g -O3 -Wall $(MACHDEP) $(INCLUDE) `freetype-config --cflags` \
+CFLAGS	= -g -O3 -Wall $(MACHDEP) $(INCLUDE) $(FREETYPE_CFLAGS) \
 				-DHAVE_STDINT_H -DBLARGG_NONPORTABLE -DBLARGG_BIG_ENDIAN -DBLARGG_CPU_POWERPC \
 				-DZLIB -DRIGHTSHIFT_IS_SAR -DCPU_SHUTDOWN -DCORRECT_VRAM_READS \
 				-D_SZ_ONE_DIRECTORY -D_LZMA_IN_CB -D_LZMA_OUT_READ \
@@ -46,7 +48,7 @@ LDFLAGS +=	-L../buildtools
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	-ldi -liso9660 -lpng -lmxml `freetype-config --libs` \
+LIBS	:=	-ldi -liso9660 -lpng -lmxml $(FREETYPE_LIBS) \
 			-lfat -lwiiuse -lz -lbte -lasnd -logc -lvorbisidec -logg -ltinysmb
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/source/filebrowser.cpp
+++ b/source/filebrowser.cpp
@@ -631,6 +631,14 @@ int BrowserChangeFolder()
 		browserList[i].isdir = 1;
 		browserList[i].icon = ICON_SD;
 		i++;
+
+		AddBrowserEntry();
+		sprintf(browserList[i].filename, "gcloader:/");
+		sprintf(browserList[i].displayname, "GC Loader");
+		browserList[i].length = 0;
+		browserList[i].isdir = 1;
+		browserList[i].icon = ICON_SD;
+		i++;
 #endif
 		AddBrowserEntry();
 		sprintf(browserList[i].filename, "smb:/");

--- a/source/utils/vm/vm.c
+++ b/source/utils/vm/vm.c
@@ -148,9 +148,9 @@ static void tlbia(void)
  * it has to adjust the stack pointer and finish filling frame_context itself
  */
 void __exception_sethandler(u32 nExcept, void (*pHndl)(frame_context*));
-extern void default_exceptionhandler();
+extern void default_exceptionhandler(frame_context*);
 // use our own exception stub because libogc stupidly requires it
-extern void dsi_handler();
+extern void dsi_handler(frame_context*);
 
 void* VM_Init(u32 VMSize, u32 MEMSize)
 {


### PR DESCRIPTION
This contains the changes in https://github.com/dborth/fceugx/pull/518

It also contains a change in `vm.c` to change the signature of the exception handlers since the build failed without it on the newest devkitPPC/libogc2 for me. I am not sure if this is correct as I am not familiar with the external function and I have not seen additional new changes that would cause it to break in the newest devkitPPC and libogc2. However, libogc2 uses this signature for their definitions.

https://github.com/extremscorner/libogc2/blob/e83aa962db3c5c4f2ba827b13f147a620a3e6b27/libogc/exception.c#L73

I tested this on my gamecube, but not a physical Wii. However, it boots and runs fine in Dolphin.

![image](https://github.com/user-attachments/assets/74ce3348-389d-4326-bcbe-96c700f9f69c)
