### PR TITLE
Fix legacy return to loader

### DIFF
--- a/source/system.cpp
+++ b/source/system.cpp
@@ -13,6 +13,7 @@
 
 #include <gccore.h>
 #include <sys/iosupport.h>
+#include <ogc/lwp_threads.h>
 
 #ifdef HW_RVL
 #include <di/di.h>
@@ -266,9 +267,14 @@ void SystemExit(int exitAction, bool autoloadedGame)
 	else // Exit to Loader
 	{
 		if (psoid[0] == PSOSDLOADID)
-			PSOReload();
+		{
+			SYS_ResetSystem(SYS_SHUTDOWN, 0, FALSE);
+			__lwp_thread_stopmultitasking(PSOReload);
+		}
 		else
+		{
 			exit(0);
+		}
 	}
 #endif
 }


### PR DESCRIPTION
This fixes the black screen issue that has been reported.
However, it would appear there's a deeper issue hiding somewhere in libogc2.

Note: Calling `exit` is sufficient to return to Swiss.